### PR TITLE
Restructured code grouping and updated file naming

### DIFF
--- a/src/Backup/Executor.php
+++ b/src/Backup/Executor.php
@@ -9,25 +9,26 @@
   program; if you did not, you can find it at http://www.gnu.org/
 */
 
-namespace Manticoresearch\Buddy\Lib;
+namespace Manticoresearch\Buddy\Backup;
 
 use Manticoresearch\Backup\Lib\FileStorage;
 use Manticoresearch\Backup\Lib\ManticoreBackup;
 use Manticoresearch\Backup\Lib\ManticoreClient;
 use Manticoresearch\Backup\Lib\ManticoreConfig;
 use Manticoresearch\Buddy\Interface\CommandExecutorInterface;
+use Manticoresearch\Buddy\Lib\Task;
 
 /**
  * This is the class to handle BACKUP ... SQL command
  */
-class BackupExecutor implements CommandExecutorInterface {
+class Executor implements CommandExecutorInterface {
   /**
    *  Initialize the executor
    *
-   * @param BackupRequest $request
+   * @param Request $request
    * @return void
    */
-	public function __construct(protected BackupRequest $request) {
+	public function __construct(protected Request $request) {
 	}
 
   /**
@@ -41,7 +42,7 @@ class BackupExecutor implements CommandExecutorInterface {
 		$isAsync = $this->request->options['async'] ?? false;
 		$method = $isAsync ? 'defer' : 'create';
 		$Task = Task::$method(
-			static function (BackupRequest $request): array {
+			static function (Request $request): array {
 				$config = new ManticoreConfig($request->configPath);
 				$client = new ManticoreClient($config);
 				$storage = new FileStorage(

--- a/src/Backup/Request.php
+++ b/src/Backup/Request.php
@@ -9,17 +9,17 @@
   program; if you did not, you can find it at http://www.gnu.org/
 */
 
-namespace Manticoresearch\Buddy\Lib;
+namespace Manticoresearch\Buddy\Backup;
 
 use Manticoresearch\Buddy\Exception\SQLQueryParsingError;
 use Manticoresearch\Buddy\Interface\CommandRequestInterface;
-use Manticoresearch\Buddy\Network\Request;
+use Manticoresearch\Buddy\Network\Request as NetRequest;
 use RuntimeException;
 
 /**
  * Request for Backup command that has parsed parameters from SQL
  */
-class BackupRequest implements CommandRequestInterface {
+class Request implements CommandRequestInterface {
 	const OPTIONS = [
 		'async' => 'bool',
 		'compress' => 'bool',
@@ -49,12 +49,12 @@ class BackupRequest implements CommandRequestInterface {
   /**
    * Create instance by parsing query into parameters
    *
-   * @param Request $request
+   * @param NetRequest $request
    *  The query itself without command prefix already
-   * @return BackupRequest
+   * @return Request
    * @throws SQLQueryParsingError
    */
-	public static function fromNetworkRequest(Request $request): BackupRequest {
+	public static function fromNetworkRequest(NetRequest $request): Request {
 		$query = $request->payload;
 		$whatPattern = 'BACKUP\s*((?P<all>ALL)|(?:TABLES?\s*(?P<table>(,?\s*[\w]+\s*)+)))';
 		$toPattern = 'TO\s*local\(\s*(?P<path>[/\\_\-a-z/0-9]+)\s*\)';
@@ -87,7 +87,7 @@ class BackupRequest implements CommandRequestInterface {
 			[]
 		) : [];
 
-		return new BackupRequest(
+		return new Request(
 			path: $path,
 			tables: $tables,
 			options: $options

--- a/src/InsertQuery/Executor.php
+++ b/src/InsertQuery/Executor.php
@@ -9,28 +9,28 @@
  program; if you did not, you can find it at http://www.gnu.org/
  */
 
-namespace Manticoresearch\Buddy\Lib;
+namespace Manticoresearch\Buddy\InsertQuery;
 
 use Exception;
 use Manticoresearch\Buddy\Interface\CommandExecutorInterface;
-
-use Manticoresearch\Buddy\Lib\ManticoreHTTPClient;
+use Manticoresearch\Buddy\Lib\Task;
+use Manticoresearch\Buddy\Network\ManticoreClient\HTTPClient;
 use RuntimeException;
 
 /**
  * This is the parent class to handle erroneous Manticore queries
  */
-class InsertQueryExecutor implements CommandExecutorInterface {
-	/** @var ManticoreHTTPClient */
-	protected ManticoreHTTPClient $manticoreClient;
+class Executor implements CommandExecutorInterface {
+	/** @var HTTPClient */
+	protected HTTPClient $manticoreClient;
 
 	/**
 	 *  Initialize the executor
 	 *
-	 * @param InsertQueryRequest $request
+	 * @param Request $request
 	 * @return void
 	 */
-	public function __construct(public InsertQueryRequest $request) {
+	public function __construct(public Request $request) {
 	}
 
 	/**
@@ -42,7 +42,7 @@ class InsertQueryExecutor implements CommandExecutorInterface {
 	public function run(): Task {
 		// We run in a thread anyway but in case if we need blocking
 		// We just waiting for a thread to be done
-		$taskFn = function (InsertQueryRequest $request, ManticoreHTTPClient $manticoreClient): array {
+		$taskFn = function (Request $request, HTTPClient $manticoreClient): array {
 			for ($i = 0, $max_i = sizeof($request->queries) - 1; $i <= $max_i; $i++) {
 				$query = $request->queries[$i];
 				// When processing the final query we need to make sure the response to client
@@ -75,10 +75,10 @@ class InsertQueryExecutor implements CommandExecutorInterface {
 	/**
 	 * Instantiating the http client to execute requests to Manticore server
 	 *
-	 * @param ManticoreHTTPClient $client
-	 * $return ManticoreHTTPClient
+	 * @param HTTPClient $client
+	 * $return HTTPClient
 	 */
-	public function setManticoreClient(ManticoreHTTPClient $client): ManticoreHTTPClient {
+	public function setManticoreClient(HTTPClient $client): HTTPClient {
 		$this->manticoreClient = $client;
 		return $this->manticoreClient;
 	}

--- a/src/InsertQuery/Request.php
+++ b/src/InsertQuery/Request.php
@@ -9,14 +9,14 @@
  program; if you did not, you can find it at http://www.gnu.org/
  */
 
-namespace Manticoresearch\Buddy\Lib;
+namespace Manticoresearch\Buddy\InsertQuery;
 
 use Manticoresearch\Buddy\Enum\ManticoreEndpoint;
 use Manticoresearch\Buddy\Enum\RequestFormat;
-use Manticoresearch\Buddy\Lib\QueryParserLoader;
-use Manticoresearch\Buddy\Network\Request;
+use Manticoresearch\Buddy\Network\Request as NetRequest;
+use Manticoresearch\Buddy\QueryParser\Loader;
 
-class InsertQueryRequest  {
+class Request  {
 	/** @var array<string> */
 	public array $queries = [];
 
@@ -30,15 +30,15 @@ class InsertQueryRequest  {
 	}
 
 	/**
-	 * @param Request $request
-	 * @return InsertQueryRequest
+	 * @param NetRequest $request
+	 * @return self
 	 */
-	public static function fromNetworkRequest(Request $request): InsertQueryRequest {
+	public static function fromNetworkRequest(NetRequest $request): self {
 		$self = new self();
 		// Resolve the possible ambiguity with Manticore query format as it may not correspond to request format
 		$queryFormat = in_array($request->endpoint, [ManticoreEndpoint::Cli, ManticoreEndpoint::Sql])
 			? RequestFormat::SQL : RequestFormat::JSON;
-		$parser = QueryParserLoader::getInsertQueryParser($queryFormat);
+		$parser = Loader::getInsertQueryParser($queryFormat);
 		$self->queries[] = $self->buildCreateTableQuery(...$parser->parse($request->payload));
 		$self->queries[] = $request->payload;
 		$self->endpoint = $request->endpoint;

--- a/src/Lib/QueryProcessor.php
+++ b/src/Lib/QueryProcessor.php
@@ -14,12 +14,13 @@ namespace Manticoresearch\Buddy\Lib;
 use Exception;
 use Manticoresearch\Buddy\Exception\SQLQueryCommandNotSupported;
 use Manticoresearch\Buddy\Interface\CommandExecutorInterface;
+use Manticoresearch\Buddy\Network\ManticoreClient\HTTPClient;
 use Manticoresearch\Buddy\Network\Request;
 use Psr\Container\ContainerInterface;
 
 class QueryProcessor {
 	/** @var string */
-	protected const NAMESPACE_PREFIX = __NAMESPACE__ . '\\';
+	protected const NAMESPACE_PREFIX = 'Manticoresearch\\Buddy\\';
 
 	/** @var ContainerInterface */
 	// We set this on initialization (init.php) so we are sure we have it in class
@@ -54,12 +55,10 @@ class QueryProcessor {
 		}
 		$prefix = static::extractPrefixFromQuery($request->payload);
 		debug('Executor: ' . $prefix);
-		$requestType = "{$prefix}Request";
-		$requestClassName = static::NAMESPACE_PREFIX . $requestType;
+		$requestClassName = static::NAMESPACE_PREFIX . "{$prefix}\\Request";
 		$commandRequest = $requestClassName::fromNetworkRequest($request);
-		debug('Command request: ' . $requestType . json_encode($commandRequest));
-		$executorType = "{$prefix}Executor";
-		$executorClassName = static::NAMESPACE_PREFIX . $executorType;
+		debug("Command request: {$prefix}\\Request " . json_encode($commandRequest));
+		$executorClassName = static::NAMESPACE_PREFIX . "{$prefix}\\Executor";
 		/** @var \Manticoresearch\Buddy\Interface\CommandExecutorInterface */
 		$executor = new $executorClassName($commandRequest);
 		foreach ($executor->getProps() as $prop) {
@@ -75,7 +74,7 @@ class QueryProcessor {
 	 * @return void
 	 */
 	protected static function init(): void {
-		/** @var ManticoreHTTPClient */
+		/** @var HTTPClient */
 		$manticoreClient = static::getObjFromContainer('manticoreClient');
 		$resp = $manticoreClient->sendRequest('SHOW SETTINGS');
 		/** @var array{0:array{columns:array<mixed>,data:array{Setting_name:string,Value:string}}} */

--- a/src/Network/ManticoreClient/HTTPClient.php
+++ b/src/Network/ManticoreClient/HTTPClient.php
@@ -9,14 +9,13 @@
  program; if you did not, you can find it at http://www.gnu.org/
  */
 
-namespace Manticoresearch\Buddy\Lib;
+namespace Manticoresearch\Buddy\Network\ManticoreClient;
 
 use Manticoresearch\Buddy\Enum\ManticoreEndpoint;
 use Manticoresearch\Buddy\Exception\ManticoreHTTPClientError;
-use Manticoresearch\Buddy\Lib\ManticoreResponse;
 use RuntimeException;
 
-class ManticoreHTTPClient {
+class HTTPClient {
 
 	const CONTENT_TYPE_HEADER = 'Content-Type: text/plain';
 	const CUSTOM_REDIRECT_DISABLE_HEADER = 'X-Manticore-Error-Redirect: disable';
@@ -33,13 +32,13 @@ class ManticoreHTTPClient {
 	protected string $url;
 
 	/**
-	 * @param ?ManticoreResponse $responseBuilder
+	 * @param ?Response $responseBuilder
 	 * @param ?string $url
 	 * @param ManticoreEndpoint $endpoint
 	 * @return void
 	 */
 	public function __construct(
-		protected ?ManticoreResponse $responseBuilder = null,
+		protected ?Response $responseBuilder = null,
 		?string $url = null,
 		protected ManticoreEndpoint $endpoint = ManticoreEndpoint::Cli
 	) {
@@ -52,10 +51,10 @@ class ManticoreHTTPClient {
 	}
 
 	/**
-	 * @param ManticoreResponse $responseBuilder
+	 * @param Response $responseBuilder
 	 * @return void
 	 */
-	public function setResponseBuilder(ManticoreResponse $responseBuilder): void {
+	public function setResponseBuilder(Response $responseBuilder): void {
 		$this->responseBuilder = $responseBuilder;
 	}
 
@@ -70,7 +69,7 @@ class ManticoreHTTPClient {
 		}
 		// ! we do not have filter extension in production version
 		// if (!filter_var($url, FILTER_VALIDATE_URL)) {
-			// throw new ManticoreHTTPClientError("Malformed request url '$origUrl' passed");
+		// throw new ManticoreHTTPClientError("Malformed request url '$origUrl' passed");
 		// }
 		$this->url = $url;
 	}
@@ -78,9 +77,9 @@ class ManticoreHTTPClient {
 	/**
 	 * @param string $request
 	 * @param ?ManticoreEndpoint $endpoint
-	 * @return ManticoreResponse
+	 * @return Response
 	 */
-	public function sendRequest(string $request, ManticoreEndpoint $endpoint = null): ManticoreResponse {
+	public function sendRequest(string $request, ManticoreEndpoint $endpoint = null): Response {
 		if (!isset($this->responseBuilder)) {
 			throw new RuntimeException("'responseBuilder' property of ManticoreHTTPClient class is not instantiated");
 		}

--- a/src/Network/ManticoreClient/Response.php
+++ b/src/Network/ManticoreClient/Response.php
@@ -9,12 +9,12 @@
  program; if you did not, you can find it at http://www.gnu.org/
  */
 
-namespace Manticoresearch\Buddy\Lib;
+namespace Manticoresearch\Buddy\Network\ManticoreClient;
 
 use Manticoresearch\Buddy\Exception\ManticoreResponseError ;
 use Throwable;
 
-class ManticoreResponse {
+class Response {
 
 	/**
 	 * @var array<string,mixed> $data

--- a/src/QueryParser/BaseParser.php
+++ b/src/QueryParser/BaseParser.php
@@ -9,13 +9,12 @@
  program; if you did not, you can find it at http://www.gnu.org/
  */
 
-namespace Manticoresearch\Buddy\Lib;
+namespace Manticoresearch\Buddy\QueryParser;
 
 use Manticoresearch\Buddy\Enum\Datatype;
-
 use Manticoresearch\Buddy\Interface\QueryParserInterface;
 
-abstract class QueryParser implements QueryParserInterface {
+abstract class BaseParser implements QueryParserInterface {
 
 	/**
 	 * @var string $name

--- a/src/QueryParser/JSONInsertParser.php
+++ b/src/QueryParser/JSONInsertParser.php
@@ -9,13 +9,12 @@
  program; if you did not, you can find it at http://www.gnu.org/
  */
 
-namespace Manticoresearch\Buddy\Lib;
+namespace Manticoresearch\Buddy\QueryParser;
 
 use Manticoresearch\Buddy\Enum\Datalim;
 use Manticoresearch\Buddy\Enum\Datatype;
 use Manticoresearch\Buddy\Exception\QueryParserError;
 use Manticoresearch\Buddy\Interface\InsertQueryParserInterface;
-use Manticoresearch\Buddy\Lib\JSONParser;
 
 class JSONInsertParser extends JSONParser implements InsertQueryParserInterface {
 

--- a/src/QueryParser/JSONParser.php
+++ b/src/QueryParser/JSONParser.php
@@ -9,13 +9,12 @@
  program; if you did not, you can find it at http://www.gnu.org/
  */
 
-namespace Manticoresearch\Buddy\Lib;
+namespace Manticoresearch\Buddy\QueryParser;
 
 use Manticoresearch\Buddy\Exception\QueryParserError;
 use Manticoresearch\Buddy\Interface\JSONParserInterface;
-use Manticoresearch\Buddy\Lib\QueryParser;
 
-abstract class JSONParser extends QueryParser implements JSONParserInterface {
+abstract class JSONParser extends BaseParser implements JSONParserInterface {
 
 	/**
 	 * @var bool $isNdJSON

--- a/src/QueryParser/Loader.php
+++ b/src/QueryParser/Loader.php
@@ -9,13 +9,13 @@
  program; if you did not, you can find it at http://www.gnu.org/
  */
 
-namespace Manticoresearch\Buddy\Lib;
+namespace Manticoresearch\Buddy\QueryParser;
 
 use Manticoresearch\Buddy\Enum\RequestFormat;
 use Manticoresearch\Buddy\Exception\ParserLoadError;
 use Manticoresearch\Buddy\Interface\InsertQueryParserInterface;
 
-class QueryParserLoader {
+class Loader {
 
 	/**
 	 * @param RequestFormat $reqFormat

--- a/src/QueryParser/SQLInsertParser.php
+++ b/src/QueryParser/SQLInsertParser.php
@@ -9,15 +9,14 @@
  program; if you did not, you can find it at http://www.gnu.org/
  */
 
-namespace Manticoresearch\Buddy\Lib;
+namespace Manticoresearch\Buddy\QueryParser;
 
 use Manticoresearch\Buddy\Enum\Datalim;
 use Manticoresearch\Buddy\Enum\Datatype;
 use Manticoresearch\Buddy\Exception\QueryParserError;
 use Manticoresearch\Buddy\Interface\InsertQueryParserInterface;
-use Manticoresearch\Buddy\Lib\QueryParser;
 
-class SQLInsertParser extends QueryParser implements InsertQueryParserInterface {
+class SQLInsertParser extends BaseParser implements InsertQueryParserInterface {
 
 	use \Manticoresearch\Buddy\Trait\CheckInsertDataTrait;
 
@@ -45,12 +44,6 @@ class SQLInsertParser extends QueryParser implements InsertQueryParserInterface 
 
 		$rows = $this->parseInsertRows($valExpr);
 		foreach ($rows as $row) {
-// 			$rowVals = $this->parseInsertValues($row);
-// 			$curColTypes = array_map([$this, 'detectValType'], $rowVals);
-// 			$this->error = self::checkColTypesError($curColTypes, $this->colTypes, $this->cols);
-// 			if ($this->error !== '') {
-// 				throw new QueryParserError($this->error);
-// 			}
 			self::checkUnescapedChars($row, QueryParserError::class);
 			self::checkColTypesError(
 				[$this, 'detectValType'],

--- a/src/ShowQueries/Executor.php
+++ b/src/ShowQueries/Executor.php
@@ -9,19 +9,18 @@
  program; if you did not, you can find it at http://www.gnu.org/
  */
 
-namespace Manticoresearch\Buddy\Lib;
+namespace Manticoresearch\Buddy\ShowQueries;
 
 use Manticoresearch\Buddy\Interface\CommandExecutorInterface;
-use Manticoresearch\Buddy\Lib\ManticoreHTTPClient;
-use Manticoresearch\Buddy\Lib\ShowQueriesRequest;
 use Manticoresearch\Buddy\Lib\Task;
 use Manticoresearch\Buddy\Lib\TaskPool;
+use Manticoresearch\Buddy\Network\ManticoreClient\HTTPClient;
 use RuntimeException;
 
 /**
  * This is the parent class to handle erroneous Manticore queries
  */
-class ShowQueriesExecutor implements CommandExecutorInterface {
+class Executor implements CommandExecutorInterface {
 	const COL_MAP = [
 		'connid' => 'id',
 		'last cmd' => 'query',
@@ -29,16 +28,16 @@ class ShowQueriesExecutor implements CommandExecutorInterface {
 		'host' => 'host',
 	];
 
-	/** @var ManticoreHTTPClient $manticoreClient */
-	protected ManticoreHTTPClient $manticoreClient;
+	/** @var HTTPClient $manticoreClient */
+	protected HTTPClient $manticoreClient;
 
 	/**
 	 *  Initialize the executor
 	 *
-	 * @param ShowQueriesRequest $request
+	 * @param Request $request
 	 * @return void
 	 */
-	public function __construct(public ShowQueriesRequest $request) {
+	public function __construct(public Request $request) {
 	}
 
 	/**
@@ -52,7 +51,7 @@ class ShowQueriesExecutor implements CommandExecutorInterface {
 
 		// We run in a thread anyway but in case if we need blocking
 		// We just waiting for a thread to be done
-		$taskFn = function (ShowQueriesRequest $request, ManticoreHTTPClient $manticoreClient, array $tasks): array {
+		$taskFn = function (Request $request, HTTPClient $manticoreClient, array $tasks): array {
 			// First, get response from the manticore
 			$resp = $manticoreClient->sendRequest($request->query);
 			$result = static::formatResponse($resp->getBody());
@@ -149,10 +148,10 @@ class ShowQueriesExecutor implements CommandExecutorInterface {
 	/**
 	 * Instantiating the http client to execute requests to Manticore server
 	 *
-	 * @param ManticoreHTTPClient $client
-	 * $return ManticoreHTTPClient
+	 * @param HTTPClient $client
+	 * $return HTTPClient
 	 */
-	public function setManticoreClient(ManticoreHTTPClient $client): ManticoreHTTPClient {
+	public function setManticoreClient(HTTPClient $client): HTTPClient {
 		$this->manticoreClient = $client;
 		return $this->manticoreClient;
 	}

--- a/src/ShowQueries/Request.php
+++ b/src/ShowQueries/Request.php
@@ -9,16 +9,16 @@
   program; if you did not, you can find it at http://www.gnu.org/
 */
 
-namespace Manticoresearch\Buddy\Lib;
+namespace Manticoresearch\Buddy\ShowQueries;
 
 use Manticoresearch\Buddy\Enum\ManticoreEndpoint;
 use Manticoresearch\Buddy\Interface\CommandRequestInterface;
-use Manticoresearch\Buddy\Network\Request;
+use Manticoresearch\Buddy\Network\Request as NetRequest;
 
 /**
  * Request for Backup command that has parsed parameters from SQL
  */
-class ShowQueriesRequest implements CommandRequestInterface {
+class Request implements CommandRequestInterface {
 	public string $query;
 	public ManticoreEndpoint $endpoint;
 
@@ -26,10 +26,10 @@ class ShowQueriesRequest implements CommandRequestInterface {
 	}
 
 	/**
-	 * @param Request $request
+	 * @param NetRequest $request
 	 * @return self
 	 */
-	public static function fromNetworkRequest(Request $request): ShowQueriesRequest {
+	public static function fromNetworkRequest(NetRequest $request): Request {
 		$self = new self();
 		$self->query = 'SELECT * FROM @@system.sessions';
 		$self->endpoint = $request->endpoint;

--- a/src/init.php
+++ b/src/init.php
@@ -9,10 +9,10 @@
   program; if you did not, you can find it at http://www.gnu.org/
 */
 
-use Manticoresearch\Buddy\Lib\ManticoreHTTPClient;
-use Manticoresearch\Buddy\Lib\ManticoreResponse;
-use Manticoresearch\Buddy\Lib\QueryParserLoader;
 use Manticoresearch\Buddy\Lib\QueryProcessor;
+use Manticoresearch\Buddy\Network\ManticoreClient\HTTPClient;
+use Manticoresearch\Buddy\Network\ManticoreClient\Response;
+use Manticoresearch\Buddy\QueryParser\Loader;
 use Symfony\Component\DependencyInjection\ContainerBuilder as Container;
 use Symfony\Component\DependencyInjection\Reference;
 
@@ -24,10 +24,10 @@ include_once __DIR__ . DIRECTORY_SEPARATOR
 ;
 // Build container dependencies
 $container = new Container();
-$container->register('ManticoreResponseBuilder', ManticoreResponse::class);
-$container->register('QueryParserLoader', QueryParserLoader::class);
+$container->register('ManticoreResponseBuilder', Response::class);
+$container->register('QueryParserLoader', Loader::class);
 $container
-	->register('manticoreClient', ManticoreHTTPClient::class)
+	->register('manticoreClient', HTTPClient::class)
 	->addArgument(new Reference('ManticoreResponseBuilder'))
 	->addArgument('127.0.0.1:9308');
 

--- a/src/main.php
+++ b/src/main.php
@@ -10,9 +10,9 @@
 */
 
 use Manticoresearch\Buddy\Lib\CliArgsProcessor;
-use Manticoresearch\Buddy\Lib\ManticoreHTTPClient;
 use Manticoresearch\Buddy\Lib\TaskPool;
 use Manticoresearch\Buddy\Network\EventHandler;
+use Manticoresearch\Buddy\Network\ManticoreClient\HTTPClient;
 use Manticoresearch\Buddy\Network\Server;
 use Symfony\Component\DependencyInjection\ContainerBuilder as Container;
 
@@ -21,7 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder as Container;
 $container = include_once __DIR__ . DIRECTORY_SEPARATOR . 'init.php';
 
 $opts = CliArgsProcessor::run();
-/** @var ManticoreHTTPClient $manticoreClient */
+/** @var HTTPClient $manticoreClient */
 $manticoreClient = $container->get('manticoreClient');
 $manticoreClient->setServerUrl($opts['listen']);
 Server::create()

--- a/test/Buddy/GetManticoreResponseTest.php
+++ b/test/Buddy/GetManticoreResponseTest.php
@@ -10,8 +10,8 @@
  */
 
 use Manticoresearch\Buddy\Enum\ManticoreEndpoint;
-use Manticoresearch\Buddy\Lib\ManticoreHTTPClient;
-use Manticoresearch\Buddy\Lib\ManticoreResponse;
+use Manticoresearch\Buddy\Network\ManticoreClient\HTTPClient;
+use Manticoresearch\Buddy\Network\ManticoreClient\Response;
 use Manticoresearch\BuddyTest\Lib\MockManticoreServer;
 use Manticoresearch\BuddyTest\Trait\TestHTTPServerTrait;
 use Manticoresearch\BuddyTest\Trait\TestProtectedTrait;
@@ -20,7 +20,7 @@ use PHPUnit\Framework\TestCase;
 class GetManticoreResponseTest extends TestCase {
 
 	/**
-	 * @var ManticoreHTTPClient $httpClient
+	 * @var HTTPClient $httpClient
 	 */
 	private $httpClient;
 
@@ -32,7 +32,7 @@ class GetManticoreResponseTest extends TestCase {
 	 */
 	protected function setUpServer(bool $isInErrorMode): void {
 		$serverUrl = self::setUpMockManticoreServer($isInErrorMode);
-		$this->httpClient = new ManticoreHTTPClient(new ManticoreResponse(), $serverUrl);
+		$this->httpClient = new HTTPClient(new Response(), $serverUrl);
 	}
 
 	protected function tearDown(): void {
@@ -44,15 +44,15 @@ class GetManticoreResponseTest extends TestCase {
 		$this->setUpServer(false);
 
 		$query = 'CREATE TABLE IF NOT EXISTS test(col1 text)';
-		$mntResp = new ManticoreResponse(MockManticoreServer::CREATE_RESPONSE_OK);
+		$mntResp = new Response(MockManticoreServer::CREATE_RESPONSE_OK);
 		$this->assertEquals($mntResp, $this->httpClient->sendRequest($query));
 
 		$query = 'INSERT INTO test(col1) VALUES("test")';
-		$mntResp = new ManticoreResponse(MockManticoreServer::SQL_INSERT_RESPONSE_OK);
+		$mntResp = new Response(MockManticoreServer::SQL_INSERT_RESPONSE_OK);
 		$this->assertEquals($mntResp, $this->httpClient->sendRequest($query));
 
 		$query = 'SELECT * FROM @@system.sessions';
-		$mntResp = new ManticoreResponse(MockManticoreServer::SHOW_QUERIES_RESPONSE_OK);
+		$mntResp = new Response(MockManticoreServer::SHOW_QUERIES_RESPONSE_OK);
 		$this->assertEquals($mntResp, $this->httpClient->sendRequest($query));
 	}
 
@@ -61,11 +61,11 @@ class GetManticoreResponseTest extends TestCase {
 		$this->setUpServer(true);
 
 		$query = 'CREATE TABLE IF NOT EXISTS testcol1 text';
-		$mntResp = new ManticoreResponse(MockManticoreServer::CREATE_RESPONSE_FAIL);
+		$mntResp = new Response(MockManticoreServer::CREATE_RESPONSE_FAIL);
 		$this->assertEquals($mntResp, $this->httpClient->sendRequest($query));
 
 		$query = 'INSERT INTO test(col1) VALUES("test")';
-		$mntResp = new ManticoreResponse(MockManticoreServer::SQL_INSERT_RESPONSE_FAIL);
+		$mntResp = new Response(MockManticoreServer::SQL_INSERT_RESPONSE_FAIL);
 		$this->assertEquals($mntResp, $this->httpClient->sendRequest($query));
 
 		$query = 'SELECT connid AS ID FROM @@system.sessions';
@@ -78,7 +78,7 @@ class GetManticoreResponseTest extends TestCase {
 		echo "\nTesting Manticore success response to JSON request\n";
 		$this->setUpServer(false);
 		$query = '{"index":"test","id":1,"doc":{"col1" : 1}}';
-		$mntResp = new ManticoreResponse(MockManticoreServer::JSON_INSERT_RESPONSE_OK);
+		$mntResp = new Response(MockManticoreServer::JSON_INSERT_RESPONSE_OK);
 		$this->assertEquals($mntResp, $this->httpClient->sendRequest($query, ManticoreEndpoint::Insert));
 	}
 
@@ -86,7 +86,7 @@ class GetManticoreResponseTest extends TestCase {
 		echo "\nTesting Manticore fail response to JSON request\n";
 		$this->setUpServer(true);
 		$query = '{"index":"test","id":1,"doc":{"col1" : 1}}';
-		$mntResp = new ManticoreResponse(MockManticoreServer::JSON_INSERT_RESPONSE_FAIL);
+		$mntResp = new Response(MockManticoreServer::JSON_INSERT_RESPONSE_FAIL);
 		$this->assertEquals($mntResp, $this->httpClient->sendRequest($query, ManticoreEndpoint::Insert));
 	}
 }

--- a/test/Buddy/InsertDataCheckTest.php
+++ b/test/Buddy/InsertDataCheckTest.php
@@ -11,8 +11,8 @@
 
 use Manticoresearch\Buddy\Enum\Datatype;
 use Manticoresearch\Buddy\Exception\QueryParserError;
-use Manticoresearch\Buddy\Lib\JSONInsertParser;
-use Manticoresearch\Buddy\Lib\SQLInsertParser;
+use Manticoresearch\Buddy\QueryParser\JSONInsertParser;
+use Manticoresearch\Buddy\QueryParser\SQLInsertParser;
 use Manticoresearch\Buddy\Trait\CheckInsertDataTrait;
 use Manticoresearch\BuddyTest\Trait\TestProtectedTrait;
 use PHPUnit\Framework\TestCase;

--- a/test/Buddy/src/Backup/BackupRequestTest.php
+++ b/test/Buddy/src/Backup/BackupRequestTest.php
@@ -9,9 +9,9 @@
   program; if you did not, you can find it at http://www.gnu.org/
 */
 
+use Manticoresearch\Buddy\Backup\Request as BackupRequest;
 use Manticoresearch\Buddy\Enum\ManticoreEndpoint;
 use Manticoresearch\Buddy\Enum\RequestFormat;
-use Manticoresearch\Buddy\Lib\BackupRequest;
 use Manticoresearch\Buddy\Network\Request;
 use PHPUnit\Framework\TestCase;
 

--- a/test/Buddy/src/InsertQuery/InsertQueryExecutorTest.php
+++ b/test/Buddy/src/InsertQuery/InsertQueryExecutorTest.php
@@ -11,11 +11,11 @@
 
 use Manticoresearch\Buddy\Enum\ManticoreEndpoint;
 use Manticoresearch\Buddy\Enum\RequestFormat;
-use Manticoresearch\Buddy\Lib\InsertQueryExecutor;
-use Manticoresearch\Buddy\Lib\InsertQueryRequest;
-use Manticoresearch\Buddy\Lib\ManticoreHTTPClient;
-use Manticoresearch\Buddy\Lib\ManticoreResponse;
-use Manticoresearch\Buddy\Network\Request;
+use Manticoresearch\Buddy\InsertQuery\Executor;
+use Manticoresearch\Buddy\InsertQuery\Request;
+use Manticoresearch\Buddy\Network\ManticoreClient\HTTPClient;
+use Manticoresearch\Buddy\Network\ManticoreClient\Response as ManticoreResponse;
+use Manticoresearch\Buddy\Network\Request as NetRequest;
 use Manticoresearch\Buddy\Network\Response;
 use Manticoresearch\BuddyTest\Trait\TestHTTPServerTrait;
 use PHPUnit\Framework\TestCase;
@@ -29,15 +29,15 @@ class InsertQueryExecutorTest extends TestCase {
 	}
 
 	/**
-	 * @param Request $networkRequest
+	 * @param NetRequest $networkRequest
 	 * @param string $serverUrl
 	 * @param string $resp
 	 */
-	protected function runTask(Request $networkRequest, string $serverUrl, string $resp): void {
-		$request = InsertQueryRequest::fromNetworkRequest($networkRequest);
+	protected function runTask(NetRequest $networkRequest, string $serverUrl, string $resp): void {
+		$request = Request::fromNetworkRequest($networkRequest);
 
-		$manticoreClient = new ManticoreHTTPClient(new ManticoreResponse(), $serverUrl);
-		$executor = new InsertQueryExecutor($request);
+		$manticoreClient = new HTTPClient(new ManticoreResponse(), $serverUrl);
+		$executor = new Executor($request);
 		$executor->setManticoreClient($manticoreClient);
 		ob_flush();
 		$task = $executor->run();
@@ -53,7 +53,7 @@ class InsertQueryExecutorTest extends TestCase {
 		echo "\nTesting the execution of a task with INSERT query request\n";
 		$resp = '[{"total":1,"error":"","warning":""}]';
 		$mockServerUrl = self::setUpMockManticoreServer(false);
-		$request = Request::fromArray(
+		$request = NetRequest::fromArray(
 			[
 				'version' => 1,
 				'error' => "index 'test' absent, or does not support INSERT",

--- a/test/Buddy/src/InsertQuery/InsertQueryRequestTest.php
+++ b/test/Buddy/src/InsertQuery/InsertQueryRequestTest.php
@@ -11,14 +11,14 @@
 
 use Manticoresearch\Buddy\Enum\ManticoreEndpoint;
 use Manticoresearch\Buddy\Enum\RequestFormat;
-use Manticoresearch\Buddy\Lib\InsertQueryRequest;
-use Manticoresearch\Buddy\Network\Request;
+use Manticoresearch\Buddy\InsertQuery\Request;
+use Manticoresearch\Buddy\Network\Request as NetRequest;
 use PHPUnit\Framework\TestCase;
 
 class InsertQueryRequestTest extends TestCase {
 	public function testCreationFromNetworkRequest(): void {
-		echo "\nTesting the creation of InsertQueryRequest from manticore request data struct\n";
-		$request = Request::fromArray(
+		echo "\nTesting the creation of InsertQuery\Request from manticore request data struct\n";
+		$request = NetRequest::fromArray(
 			[
 				'version' => 1,
 				'error' => '',
@@ -27,8 +27,8 @@ class InsertQueryRequestTest extends TestCase {
 				'endpoint' => ManticoreEndpoint::Cli,
 			]
 		);
-		$request = InsertQueryRequest::fromNetworkRequest($request);
-		$this->assertInstanceOf(InsertQueryRequest::class, $request);
+		$request = Request::fromNetworkRequest($request);
+		$this->assertInstanceOf(Request::class, $request);
 
 		echo "\nTesting the prepared quries after creating request are correct\n";
 

--- a/test/Buddy/src/Lib/QueryProcessorTest.php
+++ b/test/Buddy/src/Lib/QueryProcessorTest.php
@@ -9,15 +9,15 @@
  program; if you did not, you can find it at http://www.gnu.org/
  */
 
+use Manticoresearch\Buddy\Backup\Executor as BackupExecutor;
+use Manticoresearch\Buddy\Backup\Request as BackupRequest;
 use Manticoresearch\Buddy\Enum\ManticoreEndpoint;
 use Manticoresearch\Buddy\Enum\RequestFormat;
 use Manticoresearch\Buddy\Exception\SQLQueryCommandNotSupported;
-use Manticoresearch\Buddy\Lib\BackupExecutor;
-use Manticoresearch\Buddy\Lib\BackupRequest;
 use Manticoresearch\Buddy\Lib\QueryProcessor;
-use Manticoresearch\Buddy\Lib\ShowQueriesExecutor;
-use Manticoresearch\Buddy\Lib\ShowQueriesRequest;
 use Manticoresearch\Buddy\Network\Request;
+use Manticoresearch\Buddy\ShowQueries\Executor as ShowQueriesExecutor;
+use Manticoresearch\Buddy\ShowQueries\Request as ShowQueriesRequest;
 use Manticoresearch\BuddyTest\Trait\TestProtectedTrait;
 use PHPUnit\Framework\TestCase;
 

--- a/test/Buddy/src/Network/ManticoreClient/HTTPClientTest.php
+++ b/test/Buddy/src/Network/ManticoreClient/HTTPClientTest.php
@@ -10,40 +10,41 @@
  */
 
 use Manticoresearch\Buddy\Enum\ManticoreEndpoint;
-use Manticoresearch\Buddy\Lib\ManticoreHTTPClient;
-use Manticoresearch\Buddy\Lib\ManticoreResponse;
+//use Manticoresearch\Buddy\Exception\ManticoreHTTPClientError;
+use Manticoresearch\Buddy\Network\ManticoreClient\HTTPClient;
+use Manticoresearch\Buddy\Network\ManticoreClient\Response;
 use Manticoresearch\BuddyTest\Trait\TestProtectedTrait;
 use PHPUnit\Framework\TestCase;
 
-class ManticoreHTTPClientTest extends TestCase {
+class HTTPClientTest extends TestCase {
 
 	use TestProtectedTrait;
 
 	/**
-	 * @var ManticoreHTTPClient $client
+	 * @var HTTPClient $client
 	 */
 	private $client;
 
 	/**
-	 * @var ReflectionClass<ManticoreHTTPClient> $refCls
+	 * @var ReflectionClass<HTTPClient> $refCls
 	 */
 	private $refCls;
 
 	protected function setUp(): void {
-		$this->client = new ManticoreHTTPClient();
-		$this->refCls = new \ReflectionClass(ManticoreHTTPClient::class);
+		$this->client = new HTTPClient();
+		$this->refCls = new \ReflectionClass(HTTPClient::class);
 	}
 
 	public function testManticoreHTTPClientCreate(): void {
-		$this->assertInstanceOf(ManticoreHTTPClient::class, $this->client);
+		$this->assertInstanceOf(HTTPClient::class, $this->client);
 		$this->assertEquals(
-			ManticoreHTTPClient::DEFAULT_URL,
+			HTTPClient::DEFAULT_URL,
 			$this->refCls->getProperty('url')->getValue($this->client)
 		);
 		$this->assertEquals(ManticoreEndpoint::Cli, $this->refCls->getProperty('endpoint')->getValue($this->client));
 
-		$client = new ManticoreHTTPClient(new ManticoreResponse(), 'localhost:1000', ManticoreEndpoint::Insert);
-		$this->assertInstanceOf(ManticoreHTTPClient::class, $client);
+		$client = new HTTPClient(new Response(), 'localhost:1000', ManticoreEndpoint::Insert);
+		$this->assertInstanceOf(HTTPClient::class, $client);
 	}
 
 	public function testResponseUrlSetOk(): void {

--- a/test/Buddy/src/Network/ManticoreClient/ManticoreResponseTest.php
+++ b/test/Buddy/src/Network/ManticoreClient/ManticoreResponseTest.php
@@ -10,7 +10,7 @@
  */
 
 use Manticoresearch\Buddy\Exception\ManticoreResponseError ;
-use Manticoresearch\Buddy\Lib\ManticoreResponse;
+use Manticoresearch\Buddy\Network\ManticoreClient\Response;
 use Manticoresearch\BuddyTest\Trait\TestProtectedTrait;
 use PHPUnit\Framework\TestCase;
 
@@ -19,12 +19,12 @@ class ManticoreResponseTest extends TestCase {
 	use TestProtectedTrait;
 
 	/**
-	 * @var ManticoreResponse
+	 * @var Response
 	 */
 	protected $response;
 
 	/**
-	 * @var ReflectionClass<ManticoreResponse> $refCls
+	 * @var ReflectionClass<Response> $refCls
 	 */
 	protected $refCls;
 
@@ -46,8 +46,8 @@ class ManticoreResponseTest extends TestCase {
 			. "\n"
 			. '"a": 3'
 			. "\n}\n]\n}\n]";
-		$this->response = new ManticoreResponse($responseBody);
-		$this->refCls = new \ReflectionClass(ManticoreResponse::class);
+		$this->response = new Response($responseBody);
+		$this->refCls = new \ReflectionClass(Response::class);
 	}
 
 	public function testManticoreResponseCreateOk():void {
@@ -63,7 +63,7 @@ class ManticoreResponseTest extends TestCase {
 		$data = [
 			['id' => 1, 'a' => 3],
 		];
-		$this->assertInstanceOf(ManticoreResponse::class, $this->response);
+		$this->assertInstanceOf(Response::class, $this->response);
 		$this->assertNull($this->refCls->getProperty('error')->getValue($this->response));
 		$this->assertEquals($data, $this->refCls->getProperty('data')->getValue($this->response));
 		$this->assertEquals($columns, $this->refCls->getProperty('columns')->getValue($this->response));
@@ -73,7 +73,7 @@ class ManticoreResponseTest extends TestCase {
 		echo "\nTesting the fail on the creation of Manticore response\n";
 		$this->expectException(ManticoreResponseError ::class);
 		$this->expectExceptionMessage('Manticore response error: Invalid JSON found');
-		new ManticoreResponse('{"some unvalid json"}');
+		new Response('{"some unvalid json"}');
 	}
 
 	public function testHasError(): void {

--- a/test/Buddy/src/QueryParser/JSONInsertParserTest.php
+++ b/test/Buddy/src/QueryParser/JSONInsertParserTest.php
@@ -11,7 +11,7 @@
 
 use Manticoresearch\Buddy\Enum\Datatype;
 use Manticoresearch\Buddy\Exception\QueryParserError;
-use Manticoresearch\Buddy\Lib\JSONInsertParser;
+use Manticoresearch\Buddy\QueryParser\JSONInsertParser;
 use Manticoresearch\BuddyTest\Trait\TestProtectedTrait;
 use PHPUnit\Framework\TestCase;
 

--- a/test/Buddy/src/QueryParser/ParserLoaderTest.php
+++ b/test/Buddy/src/QueryParser/ParserLoaderTest.php
@@ -11,20 +11,20 @@
 
 use Manticoresearch\Buddy\Enum\RequestFormat;
 use Manticoresearch\Buddy\Interface\InsertQueryParserInterface;
-use Manticoresearch\Buddy\Lib\JSONInsertParser;
-use Manticoresearch\Buddy\Lib\QueryParserLoader;
-use Manticoresearch\Buddy\Lib\SQLInsertParser;
+use Manticoresearch\Buddy\QueryParser\JSONInsertParser;
+use Manticoresearch\Buddy\QueryParser\Loader;
+use Manticoresearch\Buddy\QueryParser\SQLInsertParser;
 use PHPUnit\Framework\TestCase;
 
 class ParserLoaderTest extends TestCase {
 
 	public function testParserLoader(): void {
 		echo "\nGetting SQLInsertParser instance\n";
-		$parser = QueryParserLoader::getInsertQueryParser(RequestFormat::SQL);
+		$parser = Loader::getInsertQueryParser(RequestFormat::SQL);
 		$this->assertInstanceOf(SQLInsertParser::class, $parser);
 		$this->assertInstanceOf(InsertQueryParserInterface::class, $parser);
 		echo "\nGetting JSONInsertParser instance\n";
-		$parser = QueryParserLoader::getInsertQueryParser(RequestFormat::JSON);
+		$parser = Loader::getInsertQueryParser(RequestFormat::JSON);
 		$this->assertInstanceOf(JSONInsertParser::class, $parser);
 	}
 

--- a/test/Buddy/src/QueryParser/SQLInsertParserTest.php
+++ b/test/Buddy/src/QueryParser/SQLInsertParserTest.php
@@ -10,7 +10,7 @@
  */
 
 use Manticoresearch\Buddy\Enum\Datatype;
-use Manticoresearch\Buddy\Lib\SQLInsertParser;
+use Manticoresearch\Buddy\QueryParser\SQLInsertParser;
 use Manticoresearch\BuddyTest\Trait\TestProtectedTrait;
 use PHPUnit\Framework\TestCase;
 

--- a/test/Buddy/src/ShowQueries/ExecutorTest.php
+++ b/test/Buddy/src/ShowQueries/ExecutorTest.php
@@ -11,15 +11,15 @@
 
 use Manticoresearch\Buddy\Enum\ManticoreEndpoint;
 use Manticoresearch\Buddy\Enum\RequestFormat;
-use Manticoresearch\Buddy\Lib\ManticoreHTTPClient;
-use Manticoresearch\Buddy\Lib\ManticoreResponse;
-use Manticoresearch\Buddy\Lib\ShowQueriesExecutor;
-use Manticoresearch\Buddy\Lib\ShowQueriesRequest;
-use Manticoresearch\Buddy\Network\Request;
+use Manticoresearch\Buddy\Network\ManticoreClient\HTTPClient;
+use Manticoresearch\Buddy\Network\ManticoreClient\Response;
+use Manticoresearch\Buddy\Network\Request as NetRequest;
+use Manticoresearch\Buddy\ShowQueries\Executor;
+use Manticoresearch\Buddy\ShowQueries\Request;
 use Manticoresearch\BuddyTest\Trait\TestHTTPServerTrait;
 use PHPUnit\Framework\TestCase;
 
-class ShowQueriesExecutorTest extends TestCase {
+class ExecutorTest extends TestCase {
 
 	use TestHTTPServerTrait;
 
@@ -40,7 +40,7 @@ class ShowQueriesExecutorTest extends TestCase {
 			. "\n}]", true
 		);
 
-		$request = Request::fromArray(
+		$request = NetRequest::fromArray(
 			[
 				'error' => "sphinxql: syntax error, unexpected identifier, expecting VARIABLES near 'QUERIES'",
 				'payload' => 'SHOW QUERIES',
@@ -50,10 +50,10 @@ class ShowQueriesExecutorTest extends TestCase {
 			]
 		);
 		$serverUrl = self::setUpMockManticoreServer(false);
-		$manticoreClient = new ManticoreHTTPClient(new ManticoreResponse(), $serverUrl);
-		$request = ShowQueriesRequest::fromNetworkRequest($request);
+		$manticoreClient = new HTTPClient(new Response(), $serverUrl);
+		$request = Request::fromNetworkRequest($request);
 
-		$executor = new ShowQueriesExecutor($request);
+		$executor = new Executor($request);
 		$refCls = new ReflectionClass($executor);
 		$refCls->getProperty('manticoreClient')->setValue($executor, $manticoreClient);
 		$task = $executor->run();


### PR DESCRIPTION
I've regrouped our files according to the proposals from the corresponding issue.
Also, see please if it makes sense to make a separate group for the Task-related files, and to rename Lib\QueryProcessor to something like Lib\NetRequestProcessor.