### PR TITLE
Fix/replace where id backquoted

### DIFF
--- a/src/Plugin/Replace/Payload.php
+++ b/src/Plugin/Replace/Payload.php
@@ -107,10 +107,10 @@ final class Payload extends BasePayload {
 				&& stripos($request->payload, 'where') !== false),
 			$request
 		);
-		
+
 		return (isset($payload['REPLACE'])
 			&& isset($payload['SET'])
-			&& isset($payload['WHERE'][0]['base_expr']) && $payload['WHERE'][0]['no_quotes']['parts'][0] === 'id'
+			&& isset($payload['WHERE'][0]['no_quotes']['parts'][0]) && $payload['WHERE'][0]['no_quotes']['parts'][0] === 'id'
 			&& isset($payload['WHERE'][1]['base_expr']) && $payload['WHERE'][1]['base_expr'] === '='
 			&& isset($payload['WHERE'][2]['base_expr']) && is_numeric($payload['WHERE'][2]['base_expr'])
 			&& sizeof($payload['WHERE']) === 3);

--- a/src/Plugin/Replace/Payload.php
+++ b/src/Plugin/Replace/Payload.php
@@ -107,10 +107,10 @@ final class Payload extends BasePayload {
 				&& stripos($request->payload, 'where') !== false),
 			$request
 		);
-
+		
 		return (isset($payload['REPLACE'])
 			&& isset($payload['SET'])
-			&& isset($payload['WHERE'][0]['base_expr']) && $payload['WHERE'][0]['base_expr'] === 'id'
+			&& isset($payload['WHERE'][0]['base_expr']) && $payload['WHERE'][0]['no_quotes']['parts'][0] === 'id'
 			&& isset($payload['WHERE'][1]['base_expr']) && $payload['WHERE'][1]['base_expr'] === '='
 			&& isset($payload['WHERE'][2]['base_expr']) && is_numeric($payload['WHERE'][2]['base_expr'])
 			&& sizeof($payload['WHERE']) === 3);

--- a/src/Plugin/Replace/Payload.php
+++ b/src/Plugin/Replace/Payload.php
@@ -110,7 +110,8 @@ final class Payload extends BasePayload {
 
 		return (isset($payload['REPLACE'])
 			&& isset($payload['SET'])
-			&& isset($payload['WHERE'][0]['no_quotes']['parts'][0]) && $payload['WHERE'][0]['no_quotes']['parts'][0] === 'id'
+			&& isset($payload['WHERE'][0]['no_quotes']['parts'][0])
+			&& $payload['WHERE'][0]['no_quotes']['parts'][0] === 'id'
 			&& isset($payload['WHERE'][1]['base_expr']) && $payload['WHERE'][1]['base_expr'] === '='
 			&& isset($payload['WHERE'][2]['base_expr']) && is_numeric($payload['WHERE'][2]['base_expr'])
 			&& sizeof($payload['WHERE']) === 3);


### PR DESCRIPTION
```
mysql> create table a (id bigint, text_vector float_vector knn_type='hnsw' knn_dims='2' hnsw_similarity='l2');

mysql> insert into a (text_vector) values ((0.062986552715302, -0.011650325730443));
mysql> select * from a;
+---------------------+------------------------+
| id                  | text_vector            |
+---------------------+------------------------+
| 8217612206947172353 | 0.06298655,-0.01165033 |
+---------------------+------------------------+

mysql> replace into a set text_vector = (0.000000,0.000000) where id = 8217612206947172353;
mysql> replace into a set text_vector = (0.000000,0.000000) where id = 8217612206947172354;
mysql> select * from a;
+---------------------+-------------------+
| id                  | text_vector       |
+---------------------+-------------------+
| 8217612206947172353 | 0.000000,0.000000 |
| 8217612206947172354 | 0.000000,0.000000 |
+---------------------+-------------------+
mysql> replace into a set text_vector = (1.062986552715302, -1.011650325730443)  where id = 8217612206947172353;
mysql> replace into a set text_vector = (1.062986552715302,-1.011650325730443)  where id = 8217612206947172353;
mysql> replace into a set text_vector = (1.062986552715302, -1.011650325730443)  where `id` = 8217612206947172354;
ERROR 1064 (42000): P01: syntax error, unexpected SET, expecting VALUES near 'set text_vector = (1.062986552715302, -1.011650325730443)  where `id` = 8217612206947172354'
mysql>
```
so it fails when we have
```
WHERE `id` = 8217612206947172354;
```
but succeeds when we have
```
WHERE id = 8217612206947172354;
```

The fix changes the check for id field in the condition to check no quotes expression instead of using the base expression from the parsed query payload.