### PR TITLE
chore(deps): update manticoresearch-backup to v1.9.5

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -773,16 +773,16 @@
         },
         {
             "name": "manticoresoftware/manticoresearch-backup",
-            "version": "1.9.3",
+            "version": "1.9.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/manticoresoftware/manticoresearch-backup.git",
-                "reference": "c6e46da2f7c705e99c9f5f2595478231bc15807d"
+                "reference": "2eb83c4b460d9330ed5c519b7a1722efc8d507d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/manticoresoftware/manticoresearch-backup/zipball/c6e46da2f7c705e99c9f5f2595478231bc15807d",
-                "reference": "c6e46da2f7c705e99c9f5f2595478231bc15807d",
+                "url": "https://api.github.com/repos/manticoresoftware/manticoresearch-backup/zipball/2eb83c4b460d9330ed5c519b7a1722efc8d507d0",
+                "reference": "2eb83c4b460d9330ed5c519b7a1722efc8d507d0",
                 "shasum": ""
             },
             "require": {
@@ -822,9 +822,9 @@
             ],
             "support": {
                 "issues": "https://github.com/manticoresoftware/manticoresearch-backup/issues",
-                "source": "https://github.com/manticoresoftware/manticoresearch-backup/tree/1.9.3"
+                "source": "https://github.com/manticoresoftware/manticoresearch-backup/tree/1.9.5"
             },
-            "time": "2025-04-04T13:12:43+00:00"
+            "time": "2025-06-03T05:00:27+00:00"
         },
         {
             "name": "manticoresoftware/openmetrics",


### PR DESCRIPTION
- Bump manticoresearch-backup from v1.9.3 to v1.9.5 in composer.lock
- Update source and dist references to new version commit
- Reflect updated release timestamp and source URL