### PR TITLE
Fix APP_VERSION missing from macOS package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,9 +98,9 @@ jobs:
           echo "${{ needs.vars.outputs.version_full }}" > build/APP_VERSION
           mkdir build/bin
           cp build/${{ env.APP_NAME }} build/bin/${{ env.APP_NAME }}
-          tar czf "$name.tar.gz" -C build bin/${{ env.APP_NAME }} share
+          tar czf "$name.tar.gz" -C build bin/${{ env.APP_NAME }} share APP_VERSION
           cd build
-          zip -r "$name.zip" share/modules
+          zip -r "$name.zip" share/modules APP_VERSION
           mv "$name.zip" ..
           cd ..
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugfixes
 
 * [7920](https://github.com/manticoresoftware/manticoresearch-buddy/commit/7920d9ac9ebaf956b372b40381352bb1b7bb9538) Fix issue with getting project root directory when we run as Phar archive
+* [08e49a4](https://github.com/manticoresoftware/manticoresearch-buddy/commit/08e49a4c499055eab0fc6a0852fcc3bad47a8019) Fix APP_VERSION missing from macOS package
 
 ### Major new features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Bugfixes
 
 * [7920](https://github.com/manticoresoftware/manticoresearch-buddy/commit/7920d9ac9ebaf956b372b40381352bb1b7bb9538) Fix issue with getting project root directory when we run as Phar archive
-* [08e49a4](https://github.com/manticoresoftware/manticoresearch-buddy/commit/08e49a4c499055eab0fc6a0852fcc3bad47a8019) Fix APP_VERSION missing from macOS package
 
 ### Major new features
 


### PR DESCRIPTION
## Summary
- include `APP_VERSION` when creating release artifacts so macOS packages show the right version

## Testing
- `composer install --prefer-dist --ignore-platform-req=ext-rdkafka`
- `./bin/test` *(fails: Class "Swoole\Table" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863931b1344832d9d7193982b3f9849