### PR TITLE
added content_type field in response

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ The response JSON structure:
 | `message` | A JSON object potentially containing an `error` message for displaying and/or logging. This is what Manticore Search will forward to the end-user. |
 | `error_code` | An integer representing the HTTP error code which will be a part of the HTTP response to the user making a JSON over HTTP request. For SQL over HTTP/mysql communications, this field is ignored. |
 | `version` | Indicates the current protocol version being used. Current version is 3. |
+| `content_type` | Optional string that defines the Content-Type header value for the reply to the client. |
 
 
 Example of HTTP Response:
@@ -227,7 +228,8 @@ Example of HTTP Response:
     "b": "abc"
   },
   "error_code": 0,
-  "version": 3
+  "version": 3,
+  "content_type": "text/html"
 }
 ```
 


### PR DESCRIPTION
this change is for the https://github.com/manticoresoftware/manticoresearch/issues/3517 to properly inform client of the non default `Content-Type` 