### PR TITLE
fix: volume metrics with empty binlog path

### DIFF
--- a/src/Lib/Metric.php
+++ b/src/Lib/Metric.php
@@ -468,7 +468,7 @@ final class Metric {
 		// Iterate through files and accumulate their sizes
 		/** @var SplFileInfo $file */
 		foreach ($iterator as $file) {
-			if (strpos($file->getPathname(), $this->binlogDir) !== false
+			if (($this->binlogDir !== '' && strpos($file->getPathname(), $this->binlogDir) !== false)
 					||
 				!$file->isFile()
 					||


### PR DESCRIPTION
Do not treat an empty binlog path as a substring match for every indexed data file. Otherwise volume_size_bytes reports zero when binlog_path is empty.