### PR TITLE
fix: numeric COUNT(*) type for information_schema.tables

### DIFF
--- a/src/Plugin/Select/Handler.php
+++ b/src/Plugin/Select/Handler.php
@@ -185,7 +185,7 @@ final class Handler extends BaseHandler {
 		$descResult = $manticoreClient->sendRequest($query, $payload->path)->getResult();
 		$count = sizeof($descResult[0]['data']);
 		return TaskResult::withRow(['COUNT(*)' => $count])
-			->column('COUNT(*)', Column::String);
+			->column('COUNT(*)', Column::Long);
 	}
 
 	/**
@@ -199,7 +199,7 @@ final class Handler extends BaseHandler {
 		$descResult = $manticoreClient->sendRequest($query, $payload->path)->getResult();
 		$count = sizeof($descResult[0]['data']);
 		return TaskResult::withRow(['COUNT(*)' => $count])
-			->column('COUNT(*)', Column::String);
+			->column('COUNT(*)', Column::Long);
 	}
 
 	/**


### PR DESCRIPTION
Buddy's Select handler synthesized COUNT(*) results for information_schema.tables but declared the output column as string while returning a numeric JSON scalar in data.

That produced an inconsistent `/sql?mode=raw` payload such as:

```
curl -s 'http://127.0.0.1:19312/sql?mode=raw' --data-urlencode 'query=SELECT COUNT(*) FROM information_schema.tables'
```

Before this change the reply looked like:

```
[{"total":1,"error":"","warning":"","columns":[{"COUNT(*)":{"type":"string"}}],"data":[{"COUNT(*)":0}]}]
```

The data value was numeric, but the declared column type was string.

After this change the same curl returns a consistent payload:

```
[{"total":1,"error":"","warning":"","columns":[{"COUNT(*)":{"type":"long long"}}],"data":[{"COUNT(*)":0}]}]
```