### PR TITLE
fix(emulate-elastic): keep HEAD template probes bodyless

### DIFF
--- a/src/Plugin/EmulateElastic/Payload.php
+++ b/src/Plugin/EmulateElastic/Payload.php
@@ -105,9 +105,12 @@ final class Payload extends BasePayload {
 			case '_index_template':
 			case '_template':
 				if ($request->httpMethod !== 'PUT') {
-					// Need this to avoid sending the 404 response for Elasticdump's requests which causes its failure
 					$customError = InvalidNetworkRequestError::create('', true);
-					$customError->setResponseErrorCode(200);
+					if ($request->httpMethod !== 'HEAD') {
+						// Need this to avoid sending the 404 response for
+						// Elasticdump's requests which causes its failure
+						$customError->setResponseErrorCode(200);
+					}
 					throw $customError;
 				}
 				$self->table = end($pathParts);


### PR DESCRIPTION
Logstash 7.17 probes `HEAD /_template/ecs-logstash` during Elasticsearch output initialization.

Our emulate-elastic handling for non-PUT _template/_index_template requests forced a synthetic HTTP 200 response. For HEAD requests this ended up returning 200 with a non-empty error payload body, which could poison the keep-alive connection state for the next request.

In practice this showed up as intermittent Logstash timeouts followed by retries and duplicate inserts in the 7.17 repro.

Fix: keep the synthetic 200 behavior for non-PUT template requests that need compatibility, but do not force it for HEAD.

This PR fixes this failure in the integration tests: https://github.com/manticoresoftware/manticoresearch/actions/runs/25577477215/job/75088082240#step:3:595