### PR TITLE
fix(sharding): serialize rebalance metadata with queued failover work

### DIFF
--- a/src/Plugin/Sharding/Cluster.php
+++ b/src/Plugin/Sharding/Cluster.php
@@ -374,22 +374,23 @@ final class Cluster {
 	 * Process pending tables to add and drop in current cluster
 	 * @param Queue $queue
 	 * @param string|null $operationGroup Optional operation group for rollback
-	 * @return static
+	 * @return int Last queued id added while flushing pending tables
 	 * @throws RuntimeException
 	 * @throws ManticoreSearchClientError
 	 */
-	public function processPendingTables(Queue $queue, ?string $operationGroup = null): static {
+	public function processPendingTables(Queue $queue, ?string $operationGroup = null): int {
+		$lastQueueId = 0;
 		if ($this->tablesToDetach->count()) {
-			$this->removeTables($queue, $this->tablesToDetach->toArray(), $operationGroup);
+			$lastQueueId = $this->removeTables($queue, $this->tablesToDetach->toArray(), $operationGroup);
 			$this->tablesToDetach = new Set;
 		}
 
 		if ($this->tablesToAttach->count()) {
-			$this->addTables($queue, $this->tablesToAttach->toArray(), $operationGroup);
+			$lastQueueId = $this->addTables($queue, $this->tablesToAttach->toArray(), $operationGroup);
 			$this->tablesToAttach = new Set;
 		}
 
-		return $this;
+		return $lastQueueId;
 	}
 
 	/**

--- a/src/Plugin/Sharding/Operator.php
+++ b/src/Plugin/Sharding/Operator.php
@@ -177,6 +177,8 @@ final class Operator {
 			Buddy::info("Cleaning up uncommitted rebalance for table {$name}, group {$group}");
 			$this->getQueue()->purgeOperationGroup($group);
 			$this->state->delete("rebalance_group:{$name}");
+			$this->state->delete("rebalance_queue_ids:{$name}");
+			$this->state->delete(Table::getPendingRebalanceSchemeStateKey($name));
 			$this->state->set("rebalance:{$name}", 'idle');
 		}
 	}
@@ -354,6 +356,7 @@ final class Operator {
 					$this->state->delete("rebalance_queue_ids:{$name}");
 					$this->state->delete("rebalance_committed:{$name}");
 					$this->state->delete("rebalance_group:{$name}");
+					$this->state->delete(Table::getPendingRebalanceSchemeStateKey($name));
 					$this->state->set("rebalance:{$name}", 'idle');
 					$qStatus = $queueRow['status'];
 					Buddy::info("Rebalancing failed for table {$name}: node {$node} id {$queueId} status {$qStatus}");
@@ -361,6 +364,7 @@ final class Operator {
 				}
 			}
 
+			$this->commitPendingRebalanceScheme($name);
 			$this->state->delete("rebalance_queue_ids:{$name}");
 			$this->state->delete("rebalance_committed:{$name}");
 			$this->state->delete("rebalance_group:{$name}");
@@ -368,6 +372,72 @@ final class Operator {
 			Buddy::info("Rebalancing completed for table {$name}");
 		}
 		return $this;
+	}
+
+	/**
+	 * Whether any rebalance is currently in flight on this cluster.
+	 * Queued/running/paused rebalances must keep queue processing alive even if
+	 * some internal sharding clusters are temporarily non-primary, otherwise the
+	 * failover queue deadlocks and can never heal itself.
+	 * @return bool
+	 */
+	public function hasInFlightRebalance(): bool {
+		$list = $this->state->listRegex('rebalance:.+');
+		foreach ($list as $row) {
+			$status = $row['value'] ?? null;
+			if (is_string($status) && in_array($status, ['queued', 'running', 'paused'], true)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Apply the pending rebalance placement to system.sharding_table once all
+	 * queue-backed physical and wrapper operations have completed.
+	 * @param string $name
+	 * @return void
+	 */
+	protected function commitPendingRebalanceScheme(string $name): void {
+		$pending = $this->state->get(Table::getPendingRebalanceSchemeStateKey($name));
+		if (!is_array($pending)) {
+			return;
+		}
+
+		$table = $this->getCluster()->getSystemTableName('system.sharding_table');
+		$clusterName = $this->getCluster()->name;
+		$this->client->sendRequest(
+			"
+			DELETE FROM {$table}
+			WHERE
+			cluster = '{$clusterName}'
+			AND
+			table = '{$name}'
+			"
+		);
+
+		foreach ($pending as $row) {
+			if (!is_array($row) || !isset($row['node']) || !isset($row['shards']) || !is_array($row['shards'])) {
+				continue;
+			}
+			$shards = array_map('intval', $row['shards']);
+			sort($shards);
+			if (!$shards) {
+				continue;
+			}
+			$shardsMva = implode(',', $shards);
+			$this->client->sendRequest(
+				"
+				INSERT INTO {$table}
+				(`cluster`, `node`, `table`, `shards`)
+				VALUES
+				('{$clusterName}', '{$row['node']}', '{$name}', ({$shardsMva}))
+				"
+			);
+		}
+
+		$this->state->delete(Table::getPendingRebalanceSchemeStateKey($name));
 	}
 
 	/**

--- a/src/Plugin/Sharding/Processor.php
+++ b/src/Plugin/Sharding/Processor.php
@@ -60,9 +60,13 @@ final class Processor extends BaseProcessor {
 			return false;
 		}
 
-		// Only check sharding cluster states when there is actually work to do —
-		// avoids a SHOW STATUS round-trip on every tick when the queue is idle.
+		// Only gate queue processing on internal-cluster readiness for ordinary
+		// work. During an in-flight rebalance/failover we must keep processing the
+		// queue even while some internal clusters are non-primary, otherwise the
+		// queued bootstrap/drop/recreate steps can never run and the rebalance
+		// deadlocks forever.
 		if ($operator->getQueue()->hasPending($operator->node)
+			&& !$operator->hasInFlightRebalance()
 			&& !Cluster::areAllShardingClustersPrimary($this->client)
 		) {
 			return false;

--- a/src/Plugin/Sharding/Queue.php
+++ b/src/Plugin/Sharding/Queue.php
@@ -608,26 +608,29 @@ final class Queue {
 	 * @return bool
 	 */
 	protected function isGroupCommitted(string $operationGroup): bool {
-		if (isset($this->committedGroups[$operationGroup])) {
-			return $this->committedGroups[$operationGroup];
+		if (($this->committedGroups[$operationGroup] ?? false) === true) {
+			return true;
 		}
 
-		// Query state table for rebalance_committed:* keys matching this group
-		$stateTable = $this->cluster->getSystemTableName('system.sharding_state');
-		$query = "SELECT `value` FROM {$stateTable} WHERE `key` LIKE 'rebalance_committed:%' LIMIT 100";
+		// Query state table for rebalance_committed:* keys matching this group.
+		// Negative results are intentionally not cached because the master can still
+		// finish publishing the commit marker shortly after queue items become visible.
+		// Read the locally replicated state table instead of the cluster-prefixed alias.
+		// During failover/rebalance the local state already has the commit marker, while
+		// cluster-prefixed reads can lag or be unavailable exactly when workers need to
+		// decide whether they may start consuming the rebalance group.
+		$query = 'SELECT value[0] AS value FROM system.sharding_state '
+			. "WHERE REGEX(`key`, 'rebalance_committed:.+') LIMIT 100";
 		/** @var array{0?:array{data?:array<array{value:string}>}} */
 		$res = $this->client->sendRequest($query)->getResult();
 
 		foreach ($res[0]['data'] ?? [] as $row) {
-			/** @var string $decoded */
-			$decoded = json_decode(trim((string)$row['value'], '[]'), true);
-			if ($decoded === $operationGroup) {
+			if (trim((string)$row['value']) === $operationGroup) {
 				$this->committedGroups[$operationGroup] = true;
 				return true;
 			}
 		}
 
-		$this->committedGroups[$operationGroup] = false;
 		return false;
 	}
 

--- a/src/Plugin/Sharding/State.php
+++ b/src/Plugin/Sharding/State.php
@@ -124,7 +124,7 @@ final class State {
 		foreach (($res[0]['data'] ?? []) as $row) {
 			$list[] = [
 				'key' => $row['key'],
-				'value' => simdjson_decode($row['value'], true),
+				'value' => $this->normalizeFetchedValue($row['value']),
 			];
 		}
 
@@ -144,14 +144,35 @@ final class State {
 			->getResult();
 		/** @var array{0:array{data:array{0?:array{value:string}}}} $res */
 		$value = $res[0]['data'][0]['value'] ?? null;
-		if (is_string($value)) {
-			$value = trim($value);
-			// Manticore returns unquoted string for empty string
-			if (!str_starts_with($value, '{') && !str_ends_with($value, '}')) {
-				return $value;
-			}
+		return isset($value) ? $this->normalizeFetchedValue($value) : null;
+	}
+
+	/**
+	 * Manticore returns raw scalars for value[0] projections, but JSON strings/objects
+	 * are also possible when the first item itself is structured. Decode only when the
+	 * payload still looks like JSON and otherwise keep the raw scalar.
+	 */
+	private function normalizeFetchedValue(mixed $value): mixed {
+		if (!is_string($value)) {
+			return $value;
 		}
-		return isset($value) ? simdjson_decode($value, true) : null;
+
+		$value = trim($value);
+		if ($value === '') {
+			return $value;
+		}
+
+		$firstChar = $value[0];
+		$looksLikeJson = $firstChar === '{' || $firstChar === '[' || $firstChar === '"';
+		if (!$looksLikeJson) {
+			return $value;
+		}
+
+		try {
+			return simdjson_decode($value, true);
+		} catch (\Throwable) {
+			return $value;
+		}
 	}
 
 	/**

--- a/src/Plugin/Sharding/Table.php
+++ b/src/Plugin/Sharding/Table.php
@@ -274,9 +274,7 @@ final class Table {
 			$clusterMap = $schema->reduce($reduceFn, new Map);
 
 			// Now process all postponed pending tables to attach to each cluster
-			foreach ($clusterMap as $cluster) {
-				$cluster->processPendingTables($queue, $operationGroup);
-			}
+			$this->flushPendingClusterTables($queue, $clusterMap, $operationGroup);
 
 			/** @var Set<int> */
 			$queueIds = new Set;
@@ -626,6 +624,11 @@ final class Table {
 				return;
 			}
 
+			// Keep system.sharding_table on the last committed placement until the
+			// queued physical shard moves and wrapper recreation finish. During the
+			// rebalance window the new placement lives only in state.
+			$this->storePendingRebalanceScheme($newSchema);
+
 			// Mark as committed — nodes will now start processing queue items for this group
 			$state->set("rebalance_committed:{$this->name}", $operationGroup);
 			$state->set($rebalanceKey, 'queued');
@@ -776,6 +779,9 @@ final class Table {
 		$rebalanceKey = "rebalance:{$this->name}";
 		$state->set($rebalanceKey, 'idle');
 		$state->delete("rebalance_group:{$this->name}");
+		$state->delete("rebalance_committed:{$this->name}");
+		$state->delete("rebalance_queue_ids:{$this->name}");
+		$state->delete(self::getPendingRebalanceSchemeStateKey($this->name));
 		$this->clearStopSignal();
 		return true;
 	}
@@ -836,6 +842,9 @@ final class Table {
 			// Mark as failed with rollback info
 			$state->set($rebalanceKey, 'failed');
 			$state->delete("rebalance_group:{$this->name}");
+			$state->delete("rebalance_committed:{$this->name}");
+			$state->delete("rebalance_queue_ids:{$this->name}");
+			$state->delete(self::getPendingRebalanceSchemeStateKey($this->name));
 
 			// Store error information for debugging
 			$errorInfo = [
@@ -986,6 +995,23 @@ final class Table {
 	}
 
 	/**
+	 * Flush any postponed ALTER CLUSTER ADD/DROP work and return the last live
+	 * queue id that wrapper recreation must wait on.
+	 * @param Queue $queue
+	 * @param Map<string,Cluster> $clusterMap
+	 * @param string $operationGroup
+	 * @return int
+	 */
+	private function flushPendingClusterTables(Queue $queue, Map $clusterMap, string $operationGroup = ''): int {
+		$lastQueueId = 0;
+		foreach ($clusterMap as $cluster) {
+			$lastQueueId = max($lastQueueId, $cluster->processPendingTables($queue, $operationGroup));
+		}
+
+		return $lastQueueId;
+	}
+
+	/**
 	 * Rebalance shards for a single node
 	 * @param Queue $queue
 	 * @param array{node:string,shards:Set<int>,connections:Set<string>} $row
@@ -1089,12 +1115,30 @@ final class Table {
 			fn ($row) => $inactiveNodes->contains($row['node'])
 		);
 
-		// Process affected shards for rebalancing
-		$this->processAffectedShards($queue, $affectedSchema, $newSchema, $shardNodesMap, $clusterMap, $operationGroup);
+		// Process affected shards for rebalancing and then flush the postponed
+		// ALTER CLUSTER ADD work that actually materializes the missing replicas on
+		// surviving nodes.
+		$clusterMap = $this->processAffectedShards(
+			$queue,
+			$affectedSchema,
+			$newSchema,
+			$shardNodesMap,
+			$clusterMap,
+			$operationGroup
+		);
+		$lastLiveQueueId = $this->flushPendingClusterTables($queue, $clusterMap, $operationGroup);
 
-		// Update schema in database FIRST, then create distributed tables
-		$this->updateScheme($newSchema);
-		return $this->createDistributedTablesFromSchema($queue, $newSchema, $operationGroup);
+		// Recreate public shard wrappers from the target layout, but leave
+		// system.sharding_table untouched until the queued work has finished.
+		// The wrapper DROP/CREATE chain must also wait for the last live shard
+		// bootstrap/attach query, otherwise checkRebalanceStatus() can complete
+		// while a surviving node still lacks the physical shard table.
+		if ($lastLiveQueueId > 0) {
+			$queue->setWaitForId($lastLiveQueueId);
+		}
+		$nodeTailIds = $this->createDistributedTablesFromSchema($queue, $newSchema, $operationGroup);
+		$queue->resetWaitForId();
+		return $nodeTailIds;
 	}
 
 	/**
@@ -1153,13 +1197,12 @@ final class Table {
 			);
 		}
 
-		// Update schema in database ONLY AFTER all shard movements complete
-		// CRITICAL: Wait for all shard movements to complete before updating schema
+		// Wrapper recreation should wait for shard-move queue items, but the
+		// committed metadata stays on the old layout until the whole rebalance is
+		// finished and Operator::checkRebalanceStatus() commits the pending scheme.
 		if ($lastMoveQueueId > 0) {
 			$queue->setWaitForId($lastMoveQueueId);
 		}
-
-		$this->updateScheme($newSchema);
 
 		$nodeTailIds = $this->createDistributedTablesFromSchema($queue, $newSchema, $operationGroup);
 
@@ -1221,19 +1264,18 @@ final class Table {
 			}
 		}
 
-		// Flush pending ALTER CLUSTER ADD for all new clusters
-		foreach ($clusterMap as $cluster) {
-			$cluster->processPendingTables($queue, $operationGroup);
-		}
+		// Flush pending ALTER CLUSTER ADD for all new clusters and include that tail
+		// in the wrapper wait chain; otherwise the public table can be recreated
+		// before the newly added replica has actually been attached.
+		$lastQueueId = max($lastQueueId, $this->flushPendingClusterTables($queue, $clusterMap, $operationGroup));
 
-		// Defer schema update until all queue operations complete so that the next
-		// checkBalance tick does not see the new node in the schema while it is still
-		// inactive (which would trigger a spurious handleFailedNodesRebalance and a
-		// wrong ALTER CLUSTER DROP on the not-yet-existing cluster).
+		// Recreate wrappers after the queued shard/cluster work, but do not commit
+		// the new metadata layout yet. Keeping system.sharding_table on the last
+		// committed placement avoids reporting a healthy new topology before the
+		// physical shard tables exist.
 		if ($lastQueueId > 0) {
 			$queue->setWaitForId($lastQueueId);
 		}
-		$this->updateScheme($newSchema);
 		$nodeTailIds = $this->createDistributedTablesFromSchema($queue, $newSchema, $operationGroup);
 		$queue->resetWaitForId();
 		return $nodeTailIds;
@@ -1924,6 +1966,35 @@ final class Table {
 			$this->client->sendRequest($query);
 		}
 
+		return $this;
+	}
+
+	/**
+	 * State key that holds the target rebalance placement until the queue finishes.
+	 * @param string $tableName
+	 * @return string
+	 */
+	public static function getPendingRebalanceSchemeStateKey(string $tableName): string {
+		return "rebalance_pending_scheme:{$tableName}";
+	}
+
+	/**
+	 * Persist the target rebalance placement separately from the committed schema.
+	 * @param Vector<array{node:string,shards:Set<int>,connections:Set<string>}> $scheme
+	 * @return static
+	 */
+	protected function storePendingRebalanceScheme(Vector $scheme): static {
+		$rows = [];
+		foreach ($scheme as $row) {
+			$shards = $row['shards']->toArray();
+			sort($shards);
+			$rows[] = [
+				'node' => $row['node'],
+				'shards' => array_map('intval', $shards),
+			];
+		}
+
+		$this->state->set(self::getPendingRebalanceSchemeStateKey($this->name), $rows);
 		return $this;
 	}
 

--- a/test/Plugin/Sharding/FailedNodeRebalanceMetadataCommitTest.php
+++ b/test/Plugin/Sharding/FailedNodeRebalanceMetadataCommitTest.php
@@ -1,0 +1,141 @@
+<?php declare(strict_types=1);
+
+/*
+ Copyright (c) 2026, Manticore Software LTD (https://manticoresearch.com)
+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License version 3 or any later
+ version. You should have received a copy of the GPL license along with this
+ program; if you did not, you can find it at http://www.gnu.org/
+ */
+
+use Ds\Set;
+use Ds\Vector;
+use Manticoresearch\Buddy\Base\Plugin\Sharding\Cluster;
+use Manticoresearch\Buddy\Base\Plugin\Sharding\Queue;
+use Manticoresearch\Buddy\Base\Plugin\Sharding\Table;
+use Manticoresearch\Buddy\Core\ManticoreSearch\Client;
+use Manticoresearch\Buddy\Core\ManticoreSearch\Response;
+use PHPUnit\Framework\TestCase;
+
+final class FailedNodeRebalanceMetadataCommitTest extends TestCase {
+
+	public function testFailedNodeRebalanceDoesNotRewriteCommittedSchemeImmediately(): void {
+		$queries = [];
+		$okResponse = $this->createResponse([]);
+
+		$client = $this->createMock(Client::class);
+		$client->method('sendRequest')->willReturnCallback(
+			function (string $query) use (&$queries, $okResponse): Response {
+				$queries[] = $query;
+				$schemaQueryRegex = '/SELECT\s+node\s+FROM\s+system\.sharding_table.*'
+					. 'shards\s+in\s*\(([^)]+)\)/is';
+				if (preg_match($schemaQueryRegex, $query, $m)) {
+					$shardList = array_map('intval', preg_split('/\s*,\s*/', trim($m[1])) ?: []);
+					$rows = [];
+					foreach ($shardList as $shard) {
+						if ($shard !== 0) {
+							continue;
+						}
+						$rows = [
+							['node' => 'node1'],
+							['node' => 'node2'],
+							['node' => 'node3'],
+						];
+						break;
+					}
+					return $this->createResponse($rows);
+				}
+				return $okResponse;
+			}
+		);
+
+		$cluster = new Cluster($client, 'c', 'node1');
+		$queue = new Queue($cluster, $client);
+		$table = new Table($client, $cluster, 'master_fail', 'id bigint', '');
+
+		$schema = new Vector(
+			[
+			[
+				'node' => 'node1',
+				'shards' => new Set([0]),
+				'connections' => new Set(['node1', 'node2', 'node3']),
+			],
+			[
+				'node' => 'node2',
+				'shards' => new Set([0]),
+				'connections' => new Set(['node1', 'node2', 'node3']),
+			],
+			[
+				'node' => 'node3',
+				'shards' => new Set([0]),
+				'connections' => new Set(['node1', 'node2', 'node3']),
+			],
+			]
+		);
+
+		$newSchema = new Vector(
+			[
+			[
+				'node' => 'node1',
+				'shards' => new Set([0]),
+				'connections' => new Set(['node1', 'node2']),
+			],
+			[
+				'node' => 'node2',
+				'shards' => new Set([0]),
+				'connections' => new Set(['node1', 'node2']),
+			],
+			]
+		);
+
+		$method = new ReflectionMethod(Table::class, 'handleFailedNodesRebalance');
+		$method->setAccessible(true);
+		/** @var array<string,int> $tailIds */
+		$tailIds = $method->invoke(
+			$table,
+			$queue,
+			$schema,
+			$newSchema,
+			new Set(['node3']),
+			'rebalance_master_fail_test'
+		);
+
+		$this->assertNotEmpty($tailIds, 'Failed-node rebalance should still queue wrapper work');
+
+		$metadataWrites = array_values(
+			array_filter(
+				$queries,
+				static fn(string $query): bool => (bool)preg_match(
+					'/\b(?:DELETE\s+FROM|INSERT\s+INTO)\s+system\.sharding_table\b/i',
+					$query
+				)
+			)
+		);
+		$this->assertSame(
+			[],
+			$metadataWrites,
+			'Rebalance should not rewrite system.sharding_table before queued physical work completes'
+		);
+	}
+
+	/**
+	 * @param array<array<string,mixed>> $rows
+	 */
+	private function createResponse(array $rows): Response {
+		$response = $this->createMock(Response::class);
+		$response->method('getResult')->willReturn(
+			\Manticoresearch\Buddy\Core\Network\Struct::fromData(
+				[[
+					'error' => '',
+					'warning' => '',
+					'total' => sizeof($rows),
+					'data' => $rows,
+				]]
+			)
+		);
+		$response->method('hasError')->willReturn(false);
+		$response->method('getError')->willReturn('');
+		return $response;
+	}
+}

--- a/test/Plugin/Sharding/FailedNodeRebalanceQueueSequencingTest.php
+++ b/test/Plugin/Sharding/FailedNodeRebalanceQueueSequencingTest.php
@@ -1,0 +1,243 @@
+<?php declare(strict_types=1);
+
+/*
+ Copyright (c) 2026, Manticore Software LTD (https://manticoresearch.com)
+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License version 3 or any later
+ version. You should have received a copy of the GPL license along with this
+ program; if you did not, you can find it at http://www.gnu.org/
+ */
+
+use Ds\Set;
+use Ds\Vector;
+use Manticoresearch\Buddy\Base\Plugin\Sharding\Cluster;
+use Manticoresearch\Buddy\Base\Plugin\Sharding\Queue;
+use Manticoresearch\Buddy\Base\Plugin\Sharding\Table;
+use Manticoresearch\Buddy\Core\ManticoreSearch\Client;
+use Manticoresearch\Buddy\Core\ManticoreSearch\Response;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @phpstan-type QueueItem array{
+ *   id:int,
+ *   node:string,
+ *   query:string,
+ *   rollback_query:string,
+ *   wait_for_id:int,
+ *   operation_group:string,
+ *   status:string
+ * }
+ */
+final class FailedNodeRebalanceQueueSequencingTest extends TestCase {
+
+	public function testFailedNodeRebalanceFlushesClusterAttachWorkBeforeWrapperRecreation(): void {
+		/** @var array<int,QueueItem> $queueItems */
+		$queueItems = [];
+		$okResponse = $this->createResponse([]);
+
+		$client = $this->makeQueueCapturingClient($queueItems, $okResponse);
+
+		$cluster = new Cluster($client, 'i', 'node2');
+		$queue = new Queue($cluster, $client);
+		$table = new Table($client, $cluster, 'master_fail', 'title text, gid int', '');
+
+		$schema = new Vector(
+			[
+			[
+				'node' => 'node1',
+				'shards' => new Set([0, 1]),
+				'connections' => new Set(['node1', 'node2', 'node3']),
+			],
+			[
+				'node' => 'node2',
+				'shards' => new Set([1, 2]),
+				'connections' => new Set(['node1', 'node2', 'node3']),
+			],
+			[
+				'node' => 'node3',
+				'shards' => new Set([0, 2]),
+				'connections' => new Set(['node1', 'node2', 'node3']),
+			],
+			]
+		);
+
+		$newSchema = new Vector(
+			[
+			[
+				'node' => 'node2',
+				'shards' => new Set([0, 1, 2]),
+				'connections' => new Set(['node2', 'node3']),
+			],
+			[
+				'node' => 'node3',
+				'shards' => new Set([0, 1, 2]),
+				'connections' => new Set(['node2', 'node3']),
+			],
+			]
+		);
+
+		$method = new ReflectionMethod(Table::class, 'handleFailedNodesRebalance');
+		$method->setAccessible(true);
+		/** @var array<string,int> $tailIds */
+		$tailIds = $method->invoke(
+			$table,
+			$queue,
+			$schema,
+			$newSchema,
+			new Set(['node1']),
+			'rebalance_master_fail_test'
+		);
+
+		$attachItems = array_filter(
+			$queueItems,
+			static fn(array $item): bool => $item['operation_group'] === 'rebalance_master_fail_test'
+				&& str_starts_with($item['query'], 'ALTER CLUSTER ')
+				&& str_contains($item['query'], ' ADD system.master_fail_s')
+		);
+		$this->assertNotEmpty(
+			$attachItems,
+			'Failed-node rebalance must queue ALTER CLUSTER ADD to materialize missing live replicas'
+		);
+		$lastAttachId = max(array_keys($attachItems));
+
+		/** @var array<int,QueueItem> $wrapperDropItems */
+		$wrapperDropItems = array_filter(
+			$queueItems,
+			static fn(array $item): bool => isset($tailIds[$item['node']])
+				&& $item['operation_group'] === 'rebalance_master_fail_test'
+				&& $item['query'] === 'DROP TABLE IF EXISTS master_fail OPTION force=1'
+		);
+		$this->assertCount(2, $wrapperDropItems, 'Expected wrapper drop on both surviving nodes');
+		foreach ($wrapperDropItems as $item) {
+			$this->assertSame(
+				$lastAttachId,
+				$item['wait_for_id'],
+				'Wrapper drop must wait for the last live ALTER CLUSTER ADD queue item'
+			);
+		}
+
+		$lastWrapperDropId = max(array_keys($wrapperDropItems));
+		foreach ($tailIds as $tailId) {
+			$this->assertArrayHasKey($tailId, $queueItems);
+			$this->assertStringStartsWith('CREATE TABLE `master_fail`', $queueItems[$tailId]['query']);
+			$this->assertSame(
+				$lastWrapperDropId,
+				$queueItems[$tailId]['wait_for_id'],
+				'Wrapper create must remain chained after the wrapper drops'
+			);
+		}
+	}
+
+	/**
+	 * @param array<array<string,mixed>> $rows
+	 */
+	private function createResponse(array $rows): Response {
+		$response = $this->createMock(Response::class);
+		$response->method('getResult')->willReturn(
+			\Manticoresearch\Buddy\Core\Network\Struct::fromData(
+				[[
+					'error' => '',
+					'warning' => '',
+					'total' => sizeof($rows),
+					'data' => $rows,
+				]]
+			)
+		);
+		$response->method('hasError')->willReturn(false);
+		$response->method('getError')->willReturn('');
+		return $response;
+	}
+
+	/**
+	 * @param array<int,QueueItem> $queueItems
+	 */
+	private function makeQueueCapturingClient(array &$queueItems, Response $okResponse): Client {
+		$client = $this->createMock(Client::class);
+		$client->method('sendRequest')->willReturnCallback(
+			function (string $query) use (&$queueItems, $okResponse): Response {
+				return $this->handleSendRequest($query, $queueItems, $okResponse);
+			}
+		);
+		return $client;
+	}
+
+	/**
+	 * @param array<int,QueueItem> $queueItems
+	 */
+	private function handleSendRequest(string $query, array &$queueItems, Response $okResponse): Response {
+		if (preg_match('/INSERT\s+INTO\s+i:system\.sharding_queue/is', $query)) {
+			$item = $this->parseQueueInsert($query);
+			$queueItems[$item['id']] = $item;
+			return $okResponse;
+		}
+
+		$schemaQueryRegex = '/SELECT\s+node\s+FROM\s+system\.sharding_table.*'
+			. 'shards\s+in\s*\(([^)]+)\)/is';
+		if (!preg_match($schemaQueryRegex, $query, $m)) {
+			return $okResponse;
+		}
+
+		$shardList = array_map('intval', preg_split('/\s*,\s*/', trim($m[1])) ?: []);
+		return $this->createResponse($this->schemaRowsForShards($shardList));
+	}
+
+	/**
+	 * @param list<int> $shardList
+	 * @return array<array{node:string}>
+	 */
+	private function schemaRowsForShards(array $shardList): array {
+		foreach ($shardList as $shard) {
+			if ($shard === 0) {
+				return [
+					['node' => 'node1'],
+					['node' => 'node3'],
+				];
+			}
+
+			if ($shard === 1) {
+				return [
+					['node' => 'node1'],
+					['node' => 'node2'],
+				];
+			}
+		}
+
+		return [];
+	}
+
+	/**
+	 * @return array{id:int,node:string,query:string,rollback_query:string,wait_for_id:int,operation_group:string,status:string}
+	 */
+	private function parseQueueInsert(string $sql): array {
+		$valuesPos = stripos($sql, 'VALUES');
+		self::assertNotFalse($valuesPos, 'Queue insert must contain VALUES clause');
+		$tuple = trim(substr($sql, $valuesPos + 6));
+		$start = strpos($tuple, '(');
+		$end = strrpos($tuple, ')');
+		self::assertNotFalse($start);
+		self::assertNotFalse($end);
+		$tuple = substr($tuple, $start + 1, $end - $start - 1);
+
+		$fields = array_map(
+			static fn(?string $field): string => trim((string)$field),
+			str_getcsv($tuple, ',', "'", '\\')
+		);
+
+		self::assertGreaterThanOrEqual(12, sizeof($fields), 'Unexpected queue insert tuple shape');
+
+		return [
+			'id' => (int)$fields[0],
+			'node' => $fields[1],
+			'query' => $this->decodeSqlString($fields[2]),
+			'rollback_query' => $this->decodeSqlString($fields[3]),
+			'wait_for_id' => (int)$fields[4],
+			'operation_group' => $this->decodeSqlString($fields[6]),
+			'status' => $this->decodeSqlString($fields[8]),
+		];
+	}
+
+	private function decodeSqlString(string $value): string {
+		return str_replace(["\\'", '\\\\'], ["'", '\\'], $value);
+	}
+}

--- a/test/Plugin/Sharding/OperatorInFlightRebalanceTest.php
+++ b/test/Plugin/Sharding/OperatorInFlightRebalanceTest.php
@@ -1,0 +1,80 @@
+<?php declare(strict_types=1);
+
+namespace Manticoresearch\Buddy\Base\Plugin\Sharding {
+	if (!function_exists(__NAMESPACE__ . '\\simdjson_decode')) {
+		function simdjson_decode(string $json, bool $assoc = false): mixed {
+			return json_decode($json, $assoc, 512, JSON_THROW_ON_ERROR);
+		}
+	}
+}
+
+namespace {
+
+/*
+ Copyright (c) 2026, Manticore Software LTD (https://manticoresearch.com)
+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License version 3 or any later
+ version. You should have received a copy of the GPL license along with this
+ program; if you did not, you can find it at http://www.gnu.org/
+ */
+
+	use Manticoresearch\Buddy\Base\Plugin\Sharding\Operator;
+	use Manticoresearch\Buddy\Base\Plugin\Sharding\State;
+	use Manticoresearch\Buddy\Core\ManticoreSearch\Client;
+	use Manticoresearch\Buddy\Core\ManticoreSearch\Response;
+	use PHPUnit\Framework\TestCase;
+
+	final class OperatorInFlightRebalanceTest extends TestCase {
+
+		public function testHasInFlightRebalanceReturnsTrueForQueuedRunningOrPausedStates(): void {
+			$operator = $this->makeOperatorWithRebalanceStates(['queued', 'running', 'paused']);
+			$this->assertTrue($operator->hasInFlightRebalance());
+		}
+
+		public function testHasInFlightRebalanceIgnoresCompletedStates(): void {
+			$operator = $this->makeOperatorWithRebalanceStates(['completed', 'failed']);
+			$this->assertFalse($operator->hasInFlightRebalance());
+		}
+
+		/**
+		 * @param list<string> $states
+		 */
+		private function makeOperatorWithRebalanceStates(array $states): Operator {
+			$rows = [];
+			foreach ($states as $idx => $state) {
+				$rows[] = [
+				'key' => "rebalance:t{$idx}",
+				'value' => $state,
+				];
+			}
+
+			$client = $this->createMock(Client::class);
+			$client->method('sendRequest')->willReturn($this->createResponse($rows));
+
+			$operator = (new ReflectionClass(Operator::class))->newInstanceWithoutConstructor();
+			$operator->state = new State($client);
+			return $operator;
+		}
+
+		/**
+		 * @param array<array{key:string,value:string}> $rows
+		 */
+		private function createResponse(array $rows): Response {
+			$response = $this->createMock(Response::class);
+			$response->method('getResult')->willReturn(
+				\Manticoresearch\Buddy\Core\Network\Struct::fromData(
+					[[
+					'error' => '',
+					'warning' => '',
+					'total' => sizeof($rows),
+					'data' => $rows,
+					]]
+				)
+			);
+			$response->method('hasError')->willReturn(false);
+			$response->method('getError')->willReturn('');
+			return $response;
+		}
+	}
+}

--- a/test/Plugin/Sharding/QueueCommittedGroupCacheTest.php
+++ b/test/Plugin/Sharding/QueueCommittedGroupCacheTest.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+
+/*
+ Copyright (c) 2026, Manticore Software LTD (https://manticoresearch.com)
+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License version 3 or any later
+ version. You should have received a copy of the GPL license along with this
+ program; if you did not, you can find it at http://www.gnu.org/
+ */
+
+use Manticoresearch\Buddy\Base\Plugin\Sharding\Cluster;
+use Manticoresearch\Buddy\Base\Plugin\Sharding\Queue;
+use Manticoresearch\Buddy\Core\ManticoreSearch\Client;
+use Manticoresearch\Buddy\Core\ManticoreSearch\Response;
+use PHPUnit\Framework\TestCase;
+
+final class QueueCommittedGroupCacheTest extends TestCase {
+
+	public function testIsGroupCommittedDoesNotCacheFalseBeforeCommitFlagAppears(): void {
+		$group = 'rebalance_master_fail_123';
+		$query = 'SELECT value[0] AS value FROM system.sharding_state '
+			. "WHERE REGEX(`key`, 'rebalance_committed:.+')";
+		$client = $this->createMock(Client::class);
+		$client->expects($this->exactly(2))
+			->method('sendRequest')
+			->with($this->stringContains($query))
+			->willReturnOnConsecutiveCalls(
+				$this->createResponse([]),
+				$this->createResponse([['value' => $group]]),
+			);
+
+		$cluster = new Cluster($client, 'i', '127.0.0.1:63312');
+		$queue = new Queue($cluster, $client);
+		$method = new ReflectionMethod(Queue::class, 'isGroupCommitted');
+		$method->setAccessible(true);
+
+		$this->assertFalse($method->invoke($queue, $group));
+		$this->assertTrue($method->invoke($queue, $group));
+	}
+
+	/**
+	 * @param array<array{value:string}> $rows
+	 */
+	private function createResponse(array $rows): Response {
+		$response = $this->createMock(Response::class);
+		$response->method('getResult')->willReturn(
+			\Manticoresearch\Buddy\Core\Network\Struct::fromData(
+				[[
+					'error' => '',
+					'warning' => '',
+					'total' => sizeof($rows),
+					'data' => $rows,
+				]]
+			)
+		);
+		$response->method('hasError')->willReturn(false);
+		$response->method('getError')->willReturn('');
+		return $response;
+	}
+}


### PR DESCRIPTION
Manual sharding repros exposed several ways Buddy could declare a failed-node rebalance finished before the physical cluster work had actually caught up.

What was wrong:
- handleFailedNodesRebalance() rewrote system.sharding_table immediately after calculating the target layout. That made the committed metadata advertise the new placement while ALTER CLUSTER ADD/bootstrap work was still only queued.
- wrapper DROP/CREATE steps were not chained after the last live ALTER CLUSTER ADD item, so public table recreation could run before a surviving node had the replacement shard table attached.
- Queue::isGroupCommitted() cached false results and read the cluster-prefixed state alias. During failover that could miss a rebalance_committed marker that was already visible in the local replicated state, leaving workers stuck waiting forever.
- Processor::process() refused to run queued work whenever any internal sharding cluster was non-primary, even for queued/running/paused rebalances. In practice that deadlocked failover recovery because the queue steps needed to heal the cluster never ran.

How this fixes it:
- store the target rebalance placement under rebalance_pending_scheme:* and keep system.sharding_table on the last committed layout until Operator::checkRebalanceStatus() sees all queue-backed work finish, then commit the pending scheme atomically.
- make Cluster::processPendingTables() report the last queued id, thread that id through Table helpers, and force wrapper DROP/CREATE recreation to wait for the last live shard/bootstrap/ALTER CLUSTER ADD item.
- teach Operator to detect in-flight rebalances, commit the pending scheme on success, and clean up pending scheme / queue-id state on abort or failure.
- stop caching negative committed-group lookups, query system.sharding_state directly, and normalize scalar state reads so string-valued rebalance state works reliably with value[0] projections.

Tests:
- add focused regressions for deferred metadata commit on failed-node rebalance
- add queue sequencing coverage for live ALTER CLUSTER ADD before wrapper recreation
- add coverage for in-flight rebalance detection
- add coverage for committed-group cache behavior