### PR TITLE
fix: pass auth to backup plugin requests

### DIFF
--- a/src/Plugin/Backup/Handler.php
+++ b/src/Plugin/Backup/Handler.php
@@ -12,6 +12,7 @@
 namespace Manticoresearch\Buddy\Base\Plugin\Backup;
 
 use Manticoresearch\Backup\Lib\FileStorage;
+use Manticoresearch\Backup\Lib\ManticoreAuth;
 use Manticoresearch\Backup\Lib\ManticoreBackup;
 use Manticoresearch\Backup\Lib\ManticoreClient;
 use Manticoresearch\Backup\Lib\ManticoreConfig;
@@ -19,6 +20,7 @@ use Manticoresearch\Buddy\Core\Plugin\BaseHandler;
 use Manticoresearch\Buddy\Core\Task\Column;
 use Manticoresearch\Buddy\Core\Task\Task;
 use Manticoresearch\Buddy\Core\Task\TaskResult;
+use Manticoresearch\Buddy\Core\Tool\ConfigManager;
 
 /**
  * This is the class to handle BACKUP ... SQL command
@@ -42,13 +44,15 @@ class Handler extends BaseHandler {
 		// We run in a thread anyway but in case if we need blocking
 		// We just waiting for a thread to be done
 		$isAsync = $this->payload->options['async'] ?? false;
+		$auth = $this->createAuth();
 		$task = Task::create(
 			static function (string $args): TaskResult {
 				/** @var Payload $payload */
+				/** @var ?ManticoreAuth $auth */
 				/** @phpstan-ignore-next-line */
-				[$payload] = unserialize($args);
+				[$payload, $auth] = unserialize($args);
 				$config = new ManticoreConfig($payload->configPath);
-				$client = new ManticoreClient([$config]);
+				$client = new ManticoreClient([$config], $auth);
 				$storage = new FileStorage(
 					$payload->path,
 					$payload->options['compress'] ?? false
@@ -61,7 +65,7 @@ class Handler extends BaseHandler {
 					]
 				)->column('Path', Column::String);
 			},
-			[serialize([$this->payload])]
+			[serialize([$this->payload, $auth])]
 		);
 		if ($isAsync) {
 			$task->defer();
@@ -74,5 +78,18 @@ class Handler extends BaseHandler {
 	 */
 	public function getProps(): array {
 		return [];
+	}
+
+	protected function createAuth(): ?ManticoreAuth {
+		$token = ConfigManager::get('BUDDY_AUTH_TOKEN');
+		if ($token === '') {
+			return null;
+		}
+
+		return new ManticoreAuth(
+			token: $token,
+			delegatedUser: $this->payload->user,
+			userAgent: 'Manticore Buddy/backup'
+		);
 	}
 }

--- a/src/Plugin/Backup/Payload.php
+++ b/src/Plugin/Backup/Payload.php
@@ -34,6 +34,9 @@ final class Payload extends BasePayload {
 	/** @var bool */
 	public bool $isQuotedPath = false;
 
+	/** Requesting user from the daemon auth context, empty when auth is disabled */
+	public string $user = '';
+
   /**
    * @param string $path
    * @param string[] $tables
@@ -112,6 +115,7 @@ final class Payload extends BasePayload {
 		);
 
 		$self->isQuotedPath = $isQuotedPath;
+		$self->user = $request->user ?? '';
 		$queryTokens = static::extractTokens($query);
 		$buildTokens = $self->tokenize();
 		if (array_diff($queryTokens, $buildTokens)) {

--- a/src/init.php
+++ b/src/init.php
@@ -44,6 +44,7 @@ try {
 
 $opts = CliArgsProcessor::run();
 $authToken = getenv('BUDDY_TOKEN') ?: null;
+ConfigManager::set('BUDDY_AUTH_TOKEN', $authToken ?? '');
 // Reset token
 putenv('BUDDY_TOKEN=');
 

--- a/test/Plugin/Backup/BackupPayloadTest.php
+++ b/test/Plugin/Backup/BackupPayloadTest.php
@@ -156,6 +156,24 @@ class BackupPayloadTest extends TestCase {
 	}
 
 
+	public function testSQLQueryParsingPreservesAuthenticatedUser(): void {
+		$payload = BackupPayload::fromRequest(
+			Request::fromArray(
+				[
+					'version' => Buddy::PROTOCOL_VERSION,
+					'error' => '',
+					'payload' => 'BACKUP TABLE a TO /tmp',
+					'format' => RequestFormat::SQL,
+					'endpointBundle' => ManticoreEndpoint::Sql,
+					'path' => '',
+					'user' => 'admin',
+				]
+			)
+		);
+
+		$this->assertSame('admin', $payload->user);
+	}
+
 	public function testSQLQueryParsingSucceedOnRightSyntax(): void {
 		$testingSet = [
 			'backup to /tmp',


### PR DESCRIPTION
Keep the internal Buddy bearer token available after startup, preserve the authenticated SQL user in the BACKUP payload, and pass both into the backup client so SQL BACKUP works when daemon auth is enabled.

Related issue: https://github.com/manticoresoftware/manticoresearch/issues/4844